### PR TITLE
Correct set Content-type to application/json when writing JSON

### DIFF
--- a/src/Graphics/UI/Ji.hs
+++ b/src/Graphics/UI/Ji.hs
@@ -189,7 +189,9 @@ poll sessions = do
 
 -- Write JSON to output.
 writeJson :: (MonadSnap m, Data a) => a -> m ()
-writeJson = writeString . encodeJSON
+writeJson json = do
+    modifyResponse $ setContentType "application/json"
+    (writeString . encodeJSON) json
 
 -- Write a string to output.
 writeString :: (MonadSnap m) => String -> m ()


### PR DESCRIPTION
I'm working on making this work with XUL, which is a great deal pickier under the hood than what is exposed as the browser. This isn't all that will be necessary, but it's one that's easier and (as far as I can tell) unambiguously correct.
