### PR TITLE
Cabal file serving support

### DIFF
--- a/ji.cabal
+++ b/ji.cabal
@@ -11,6 +11,10 @@ Category:            Web
 Build-type:          Simple
 Cabal-version:       >=1.2
 
+Data-files:           wwwroot/js/x.js
+                     ,wwwroot/js/jquery.js
+
+
 Library
   Hs-source-dirs:    src
   Exposed-modules:   Graphics.UI.Ji, Graphics.UI.Ji.Types

--- a/src/Graphics/UI/Ji.hs
+++ b/src/Graphics/UI/Ji.hs
@@ -85,6 +85,7 @@ import           Snap.Core
 import           Snap.Http.Server
 import           Snap.Util.FileServe
 import           Text.JSON.Generic
+import           Paths_ji
 
 
 --------------------------------------------------------------------------------
@@ -160,12 +161,15 @@ runJi session m = runReaderT (getJi m) session
 
 -- Route requests.
 router :: (Session m -> IO a) -> MVar (Map Integer (Session m)) -> Snap ()
-router worker sessions = route routes where
-  routes = [("/",handle)
-           ,("/js/",serveDirectory "wwwroot/js")
-           ,("/init",init worker sessions)
-           ,("/poll",poll sessions)
-           ,("/signal",signal sessions)]
+router worker sessions = do
+     x_js <- liftIO $ getDataFileName "wwwroot/js/x.js"
+     jquery_js <- liftIO $ getDataFileName "wwwroot/js/jquery.js"
+     route [ ("/",handle)
+            ,("/init",init worker sessions)
+            ,("/js/x.js", serveFile x_js)
+            ,("/js/jquery.js", serveFile jquery_js)
+            ,("/poll",poll sessions)
+            ,("/signal",signal sessions)]
 
 -- Setup the JS.
 handle :: Snap ()


### PR DESCRIPTION
I think this is what is necessary to serve the files out of the cabal installation rather than the source directory. I didn't include a local Paths_ji module, as in Neil's post, because I use cabal-dev to develop anyhow. I think this means if you just cabal-install 
