### PR TITLE
Added drag and drop

### DIFF
--- a/src/Graphics/UI/Threepenny.hs
+++ b/src/Graphics/UI/Threepenny.hs
@@ -24,9 +24,6 @@ module Graphics.UI.Threepenny
   ,bind
   ,handleEvent
   ,handleEvents
-  ,onClick
-  ,onHover
-  ,onBlur
   
   -- * Setting attributes
   -- $settingattributes
@@ -370,27 +367,6 @@ newClosure eventType elid thunk = do
   return (Closure key)
     
   where key = (elid,eventType)
-
--- | Bind an event handler to the click event of the given element.
-onClick :: MonadTP m
-        => Element             -- ^ The element to bind to.
-        -> (EventData -> m ()) -- ^ The event handler.
-        -> m ()
-onClick = bind "click"
-
--- | Bind an event handler to the hover event of the given element.
-onHover :: MonadTP m
-        => Element             -- ^ The element to bind to.
-        -> (EventData -> m ()) -- ^ The event handler.
-        -> m ()
-onHover = bind "mouseenter"
-
--- | Bind an event handler to the blur event of the given element.
-onBlur :: MonadTP m
-       => Element             -- ^ The element to bind to.
-       -> (EventData -> m ()) -- ^ The event handler.
-       -> m ()
-onBlur = bind "mouseleave"
 
 
 --------------------------------------------------------------------------------

--- a/src/Graphics/UI/Threepenny/Browser.hs
+++ b/src/Graphics/UI/Threepenny/Browser.hs
@@ -3,9 +3,11 @@
 module Graphics.UI.Threepenny.Browser
   (module Graphics.UI.Threepenny.DOM
   ,module Graphics.UI.Threepenny.Elements
-  ,module Graphics.UI.Threepenny.JQuery)
+  ,module Graphics.UI.Threepenny.JQuery
+  ,module Graphics.UI.Threepenny.Events)
   where
 
 import Graphics.UI.Threepenny.DOM
 import Graphics.UI.Threepenny.Elements
 import Graphics.UI.Threepenny.JQuery
+import Graphics.UI.Threepenny.Events

--- a/src/Graphics/UI/Threepenny/Events.hs
+++ b/src/Graphics/UI/Threepenny/Events.hs
@@ -1,0 +1,86 @@
+
+-- | Utility methods for handling particular events.
+
+module Graphics.UI.Threepenny.Events where
+
+import Graphics.UI.Threepenny
+
+-- | Bind an event handler to the click event of the given element.
+onClick :: MonadTP m
+        => Element             -- ^ The element to bind to.
+        -> (EventData -> m ()) -- ^ The event handler.
+        -> m ()
+onClick = bind "click"
+
+-- | Bind an event handler to the hover event of the given element.
+onHover :: MonadTP m
+        => Element             -- ^ The element to bind to.
+        -> (EventData -> m ()) -- ^ The event handler.
+        -> m ()
+onHover = bind "mouseenter"
+
+-- | Bind an event handler to the blur event of the given element.
+onBlur :: MonadTP m
+       => Element             -- ^ The element to bind to.
+       -> (EventData -> m ()) -- ^ The event handler.
+       -> m ()
+onBlur = bind "mouseleave"
+
+-- Drag events and support functions
+
+-- | Enables drag on an element.
+allowDrag :: MonadTP m => Element -> m Element
+allowDrag = setDraggable True
+
+-- | Disables drag on an element.
+blockDrag :: MonadTP m => Element -> m Element
+blockDrag = setDraggable False
+
+-- | Enables or disables drag based on boolean argument.
+setDraggable :: MonadTP m => Bool -> Element -> m Element
+setDraggable t = setAttr "draggable" (if t then "true" else "false")
+
+-- | Set the drag data for an element.  This data becomes the EventData for all drag-related events.
+setDragData :: MonadTP m => String -> Element -> m Element
+setDragData d = setAttr "ondragstart" $ "event.dataTransfer.setData('dragData', '" ++ d ++ "')"
+
+-- | Enables an element to accept drops.
+allowDrop :: MonadTP m => Element -> m Element
+allowDrop e =
+    setAttr "ondragover" "event.preventDefault()" e >>= setAttr "ondrop" "event.preventDefault()"
+
+-- | Disables an element from accepting drops.
+blockDrop :: MonadTP m => Element -> m Element
+blockDrop e = setAttr "ondragover" "" e >>= setAttr "ondrop" ""
+
+-- | Enables or disables an element from accepting drops based on boolean argument.
+setDroppable :: MonadTP m => Bool -> Element -> m Element
+setDroppable t = if t then allowDrop else blockDrop
+
+-- | Bind an event handler to the drag start event.
+onDragStart :: MonadTP m => Element -> (EventData -> m ()) -> m ()
+onDragStart = bind "dragstart"
+
+-- | Bind an event handler to the drag enter event.
+onDragEnter :: MonadTP m => Element -> (EventData -> m ()) -> m ()
+onDragEnter = bind "dragenter"
+
+-- | Bind an event handler to the drag over event.
+onDragOver :: MonadTP m => Element -> (EventData -> m ()) -> m ()
+onDragOver = bind "dragover"
+
+-- | Bind an event handler to the drag leave event.
+onDragLeave :: MonadTP m => Element -> (EventData -> m ()) -> m ()
+onDragLeave = bind "dragleave"
+
+-- | Bind an event handler to the drag event.
+onDrag :: MonadTP m => Element -> (EventData -> m ()) -> m ()
+onDrag = bind "drag"
+
+-- | Bind an event handler to the drop event.
+onDrop :: MonadTP m => Element -> (EventData -> m ()) -> m ()
+onDrop = bind "drop"
+
+-- | Bind an event handler to the drag end event.
+onDragEnd :: MonadTP m => Element -> (EventData -> m ()) -> m ()
+onDragEnd = bind "dragend"

--- a/src/Graphics/UI/driver.js
+++ b/src/Graphics/UI/driver.js
@@ -308,8 +308,19 @@ $.fn.livechange = function(ms,trigger){
               Event: handlerGuid.concat([[x]])
             },function(){});
           });
-        }
-        else {
+        } else if(eventType.match('dragstart|dragenter|dragover|dragleave|drag|drop|dragend')) {
+          $(el).bind(eventType,function(e){
+            signal({
+              Event: handlerGuid.concat([
+                e.originalEvent.dataTransfer
+                    ?[e.originalEvent.dataTransfer.getData("dragData")]
+                    :[]])
+            },function(){
+              // no action
+            });
+            return true;
+          });
+        } else {
           $(el).bind(eventType,function(e){
             signal({
               Event: handlerGuid.concat([e.which?[e.which.toString()]:[]])

--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -40,6 +40,7 @@ Library
                     ,Graphics.UI.Threepenny.Elements
                     ,Graphics.UI.Threepenny.JQuery
                     ,Graphics.UI.Threepenny.Browser
+                    ,Graphics.UI.Threepenny.Events
   Other-modules:     Control.Concurrent.Chan.Extra
                     ,Control.Monad.Extra
                     ,Control.Monad.IO


### PR DESCRIPTION
I needed drag and drop, so I threw it in there.  Right now the drag data can only be a string, but this is consistent with the EventData type and is probably sufficient until/if we decide to re-arch this thing.  It's been working fine in my app, but not extensively tested.
