### PR TITLE
Fixed #30.

### DIFF
--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -91,7 +91,7 @@ Executable threepenny-examples-bartab
     else
         buildable: False
     main-is:           BarTab.hs
-    other-modules:     Paths_threepenny_gui
+    other-modules:     Paths, Paths_threepenny_gui
     hs-source-dirs:    src
 
 Executable threepenny-examples-buttons


### PR DESCRIPTION
I added `Paths` to the `other-modules` field for the executable threepenny-examples-bartab, in the Cabal file.

Hopefully, this fixes #30.
