### PR TITLE
Add getElementsByClassName function.

### DIFF
--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -17,7 +17,9 @@ module Graphics.UI.Threepenny.Core (
         getHead, getBody,
         children, text, html, attr, style, value,
     getValuesList,
-    getElementsByTagName, getElementByTagName, getElementsById, getElementById,
+    getElementsByTagName, getElementByTagName, 
+    getElementsById, getElementById,
+    getElementsByClassName,
     
     -- * Layout
     -- | Combinators for quickly creating layouts.
@@ -316,6 +318,14 @@ getElementsById
     -> IO [Element]  -- ^ Elements with given ID.
 getElementsById window name =
     mapM fromAlive =<< Core.getElementsById window name
+
+-- | Get a list of elements by particular class.  Blocks.
+getElementsByClassName
+    :: Window        -- ^ Browser window
+    -> String        -- ^ The class string.
+    -> IO [Element]  -- ^ Elements with given class.
+getElementsByClassName window cls =
+    mapM fromAlive =<< Core.getElementsByClassName window cls
 
 {-----------------------------------------------------------------------------
     Oddball

--- a/src/Graphics/UI/Threepenny/Internal/Core.hs
+++ b/src/Graphics/UI/Threepenny/Internal/Core.hs
@@ -40,6 +40,7 @@ module Graphics.UI.Threepenny.Internal.Core
   ,getBody
   ,getElementsByTagName
   ,getElementsById
+  ,getElementsByClassName
   ,getWindow
   ,getProp
   ,getValue
@@ -611,6 +612,17 @@ getElementsById
     -> IO [Element]  -- ^ Elements with given ID.
 getElementsById window ids =
   call window (GetElementsById ids) $ \signal ->
+    case signal of
+      Elements els -> return $ Just [Element el window | el <- els]
+      _            -> return Nothing
+
+-- | Get a list of elements by particular class.  Blocks.
+getElementsByClassName
+    :: Window        -- ^ Browser window
+    -> String        -- ^ The class string.
+    -> IO [Element]  -- ^ Elements with given class.
+getElementsByClassName window cls =
+  call window (GetElementsByClassName cls) $ \signal ->
     case signal of
       Elements els -> return $ Just [Element el window | el <- els]
       _            -> return Nothing

--- a/src/Graphics/UI/Threepenny/Internal/Types.hs
+++ b/src/Graphics/UI/Threepenny/Internal/Types.hs
@@ -96,6 +96,7 @@ data Config = Config
 data Instruction
   = Debug String
   | SetToken Integer
+  | GetElementsByClassName String
   | GetElementsById [String]
   | GetElementsByTagName String
   | SetStyle ElementId [(String,String)]

--- a/src/Graphics/UI/driver.js
+++ b/src/Graphics/UI/driver.js
@@ -274,6 +274,18 @@ $.fn.livechange = function(ms,trigger){
         reply({ Elements: els });
         break;
       }
+      case "GetElementsByClassName": {
+        var elements = document.getElementsByClassName(event.GetElementsByClassName);
+        var els = [];
+        var len = elements.length;
+        for(var i = 0; i < len; i++) {
+          els.push({
+            Element: elementToElid(elements[i])
+          });
+        }
+        reply({ Elements: els });
+        break;
+      }
       case "SetStyle": {
         var set = event.SetStyle;
         var id = set[0];

--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -97,6 +97,8 @@ Library
                     ,data-default
                     ,transformers
                     ,stm
+                    ,attoparsec-enumerator
+                    ,MonadCatchIO-transformers
                     
 Executable threepenny-examples-bartab
     if flag(buildExamples)


### PR DESCRIPTION
getElementsByClassName can be useful in some situations. Although not supported in IE8-, it's IE's fault.
