### PR TITLE
Adjusting a 'Hashable' instance for compatibility with 'hashable-1.2.*'.

### DIFF
--- a/src/Reactive/Threepenny/PulseLatch.hs
+++ b/src/Reactive/Threepenny/PulseLatch.hs
@@ -42,7 +42,7 @@ runEvalP pulses m = do
 type Handler  = EvalP (IO ())
 data Priority = DoLatch | DoIO deriving (Eq,Show,Ord,Enum)
 
-instance Hashable Priority where hash = fromEnum
+instance Hashable Priority where hashWithSalt _ = fromEnum
 
 data Pulse a = Pulse
     { addHandlerP :: ((Unique, Priority), Handler) -> Build ()


### PR DESCRIPTION
With hashable-1.2.*, hash is not a class method of Hashable anymore; rather, it is defined in terms of hashWithSalt. I needed this change to build the embed-frp branch here.

(Sorry for the duplicated pull request.)
