### PR TITLE
Enable resource file embedding. #27

### DIFF
--- a/src/Graphics/UI/Threepenny/Internal/Include.hs
+++ b/src/Graphics/UI/Threepenny/Internal/Include.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell, CPP #-}
 module Graphics.UI.Threepenny.Internal.Include (include) where
  
 import Data.Functor

--- a/src/Graphics/UI/Threepenny/Internal/Resources.hs
+++ b/src/Graphics/UI/Threepenny/Internal/Resources.hs
@@ -3,6 +3,29 @@ module Graphics.UI.Threepenny.Internal.Resources where
 
 import           Data.Text                               (Text)
 import qualified Data.Text                               as Text
+import           Graphics.UI.Threepenny.Internal.Include
+
+
+jsDriverCode    :: Text
+cssDriverCode   :: Text
+defaultHtmlFile :: Text
+
+
+jsDriverCode = Text.unlines $ map Text.pack
+    [ [include|Graphics/UI/jquery.js|]
+    , [include|Graphics/UI/jquery-cookie.js|]
+    , [include|Graphics/UI/driver.js|]
+    ]
+
+cssDriverCode = Text.pack [include|Graphics/UI/driver.css|]
+
+defaultHtmlFile = Text.pack [include|Graphics/UI/index.html|]
+
+
+{-
+-- Disabled code:
+-- Do not embed files with executables.
+
 import qualified Data.Text.IO                            as Text
 import           System.FilePath
 import           System.IO.Unsafe
@@ -14,11 +37,6 @@ getDataDir = fmap (</> "src" </> "Graphics" </> "UI") Paths_threepenny_gui.getDa
 #else
 getDataDir = return $ "Graphics" </> "UI"
 #endif
-
-
-jsDriverCode    :: Text
-cssDriverCode   :: Text
-defaultHtmlFile :: Text
 
 
 jsDriverCode = unsafePerformIO $
@@ -35,20 +53,5 @@ readFiles files = do
     return $ Text.unlines ys
 
 getDataFile x = unsafePerformIO $ fmap (</> x) getDataDir
-
-
-{-
--- Temporarily disabled code.
--- Use quasiquotation to bundle resource files with executable.
-
-jsDriverCode = Text.unlines $ map Text.pack
-    [ [include|Graphics/UI/jquery.js|]
-    , [include|Graphics/UI/jquery-cookie.js|]
-    , [include|Graphics/UI/driver.js|]
-    ]
-
-cssDriverCode = Text.pack [include|Graphics/UI/driver.css|]
-
-defaultHtmlFile = Text.pack [include|Graphics/UI/index.html|]
 
 -}

--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -39,12 +39,10 @@ Cabal-version:       >=1.8
 
 Extra-Source-Files:  src/Graphics/UI/*.html
                     ,src/Graphics/UI/*.js
+                    ,src/Graphics/UI/*.css
 
 Data-dir:            .
-Data-files:          src/Graphics/UI/*.js
-                    ,src/Graphics/UI/*.html
-                    ,src/Graphics/UI/*.css
-                    ,wwwroot/css/*.css
+Data-files:          wwwroot/css/*.css
                     ,wwwroot/css/*.png
                     ,wwwroot/*.html
                     ,wwwroot/*.txt
@@ -78,6 +76,7 @@ Library
                     ,Control.Concurrent.Delay
                     ,Graphics.UI.Threepenny.Internal.Core
                     ,Graphics.UI.Threepenny.Internal.Resources
+                    ,Graphics.UI.Threepenny.Internal.Include
                     ,Graphics.UI.Threepenny.Internal.Types
                     ,Reactive.Threepenny.PulseLatch
                     ,Reactive.Threepenny.Memo
@@ -101,6 +100,7 @@ Library
                     ,network
                     ,filepath
                     ,data-default
+                    ,template-haskell
                     ,transformers
                     ,stm
                     ,attoparsec-enumerator


### PR DESCRIPTION
To work around the Haddock bug, a seemingly superfluous TemplateHaskell pragma
was added to 'Graphics.UI.Threepenny.Internal.Include'.

Additional comments:
- Inspired by http://code.google.com/p/ndmitchell/issues/detail?id=539
- One side-effect of re-enabling the quasiquotes is that, when compiling under Wine, a bizarre linkage failure   happens. Fortunately (as I need Wine to make Win32 builds for my project) there is a tolerable workaround for that(*).

---

(_) Abusing of your hospitality: what are the odds of you including my Wine hack in 0.4._? I assure you it is not pretty! :smile: (It involves building the `Internal.Resources` module as a separate library and then using a `-fwine` cabal flag and a corresponding `-DWINE` CPP one to have it loaded.)
