### PR TITLE
Add 'sinkWhen' function for conditionally updating an 'Attribute'.

### DIFF
--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -40,7 +40,7 @@ module Graphics.UI.Threepenny.Core (
     -- | For a list of predefined attributes, see "Graphics.UI.Threepenny.Attributes".
     (#), (#.),
     Attr, WriteAttr, ReadAttr, ReadWriteAttr(..),
-    set, sink, get, mkReadWriteAttr, mkWriteAttr, mkReadAttr,
+    set, sink, sinkWhen, get, mkReadWriteAttr, mkWriteAttr, mkReadAttr,
     
     -- * Widgets
     Widget(..), element, widget,
@@ -505,6 +505,23 @@ sink attr bi mx = do
         i <- currentValue bi
         runUI window $ set' attr i x
         Reactive.onChange bi  $ \i -> runUI window $ set' attr i x  
+    return x
+
+-- | Like 'sink', but the attribute is only updated if the boolean 'Behavior'
+-- is 'True'.
+--
+-- Note: If the boolean 'Behavior' changes to 'True', the attribute will be
+-- updated to the current value of the other 'Behavior'.
+sinkWhen :: Behavior Bool -> ReadWriteAttr x i o -> Behavior i -> UI x -> UI x
+sinkWhen bp attr bi mx = do
+    x <- mx
+    window <- askWindow
+    let bpi = pure (,) <*> bp <*> bi
+    liftIOLater $ do
+        (p, i) <- currentValue bpi
+        runUI window $ when p $ set' attr i x
+        Reactive.onChange bpi $
+            \(p, i) -> runUI window $ when p $ set' attr i x
     return x
 
 -- | Get attribute value.


### PR DESCRIPTION
Inspired by [your minimal widget example](https://gist.github.com/HeinrichApfelmus/6495734); more specifically, by how it disconnects view and model while the user edits. I believe the main selling point of `sinkWhen` is eliminating one reason for using `onChange` directly. The implementation combines boolean and value into a pair to ensure predictable results if both Behaviors change simultaneously (with separate `onChange` handlers for each Behavior, if the boolean changed to `False` at the same time that the value changed then whether the Attribute would be updated would depend on the execution order of the handlers).

P.S.: From reading the Reactive.Threepenny internals, I gather that making a pair in the way I just did is very cheap, as Behaviors synthesized with the `Applicative` instance are not cached. Is that correct?
