### PR TITLE
Add bug-reports section to cabal file

### DIFF
--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -34,6 +34,7 @@ License-file:        LICENSE
 Author:              Chris Done, Heinrich Apfelmus
 Maintainer:          Heinrich Apfelmus <apfelmus at quantentunnel dot de>
 Homepage:            http://www.haskell.org/haskellwiki/Threepenny-gui
+bug-reports:         https://github.com/HeinrichApfelmus/threepenny-gui/issues
 Category:            Web, GUI
 Build-type:          Simple
 Cabal-version:       >=1.8


### PR DESCRIPTION
Just as title says. It's quite handy to be able to jump directly to bug tracker from hackage.
