### PR TITLE
With out this patch loading the a the page in the below example results ...

### DIFF
--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -140,7 +140,8 @@ data    Elem
 -- but this is ok since live references never change.
 fromAlive :: Core.Element -> IO Element
 fromAlive e@(Core.Element elid Session{..}) = do
-    Just events <- Map.lookup elid <$> readMVar sElementEvents
+    mevents <- Map.lookup elid <$> readMVar sElementEvents
+    let Just events = mevents
     Element events <$> newMVar (Alive e)
 
 -- Update an element that may be in Limbo.


### PR DESCRIPTION
With out this patch loading the a the page in the below example results in the

following error:

```
getByETest.hs: user error (Pattern match failure in do expression at src/Graphics/UI/Threepenny/Core.hs:143:5-15)
```

The same problem exists with all getElement functions as far as I can tell.

example code that demoenstrates this problem can be found at the following paste
http://lpaste.net/95800

This fixes an error found on
os: 10.8.5
ghc: 7.6.3

I have also posted to SO for further insight it does not seem like I should expect a difference between pattern matching in do notation vs let.

http://stackoverflow.com/questions/20026610/pattern-matching-in-do-notation-vs-let
