### PR TITLE
Bump dependency upper version bounds

### DIFF
--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -46,6 +46,10 @@ flag buildExamples
     description: Build example executables.
     default:     False
 
+flag network-uri
+    description: Get Network.URI from the network-uri package
+    default:     True
+
 flag rebug
     description: The library uses some techniques that are highly
                  non-deterministic, for example garbage collection and concurrency.
@@ -92,7 +96,7 @@ Library
       cpp-options:  -DREBUG
       ghc-options:  -O2   
   build-depends:     base                   >= 4     && < 5
-                    ,aeson                  >= 0.6   && < 0.8
+                    ,aeson                  >= 0.6   && < 0.9
                     ,attoparsec-enumerator  == 0.3.*
                     ,bytestring             >= 0.9.2 && < 0.11
                     ,containers             >= 0.4.2 && < 0.6
@@ -101,20 +105,23 @@ Library
                     ,filepath               == 1.3.*
                     ,hashable               >= 1.1.0  && < 1.3
                     ,MonadCatchIO-transformers == 0.3.*
-                    ,network                >= 2.3.0  && < 2.6
                     ,safe                   == 0.3.*
                     ,snap-server            == 0.9.*
                     ,snap-core              == 0.9.*
                     ,stm                    >= 2.3    && < 2.5
                     ,template-haskell       >= 2.7.0  && < 2.10
-                    ,text                   >= 0.11   && < 1.2
+                    ,text                   >= 0.11   && < 1.3
                     ,time                   == 1.4.*
                     ,transformers           >= 0.3.0  && < 0.5
                     ,unordered-containers   == 0.2.*
                     ,utf8-string            == 0.3.*
-                    ,websockets             == 0.8.*
-                    ,websockets-snap        == 0.8.*
+                    ,websockets             >= 0.8    && < 0.10
+                    ,websockets-snap        >= 0.8    && < 0.10
                     ,vault                  == 0.3.*
+  if flag(network-uri)
+      build-depends: network-uri            >= 2.6    && < 2.7
+  else
+      build-depends: network                >= 2.3.0  && < 2.6
                     
 Executable threepenny-examples-bartab
     if flag(buildExamples)


### PR DESCRIPTION
This bumps up the upper version bounds of `aeson`, `text`, `websockets`, and `websockets-snap` to allow the latest versions of each to be used with `threepenny-gui`. This also introduces a fix for the recent `network`/[`network-uri`](http://hackage.haskell.org/package/network-uri) split
