### PR TITLE
Fix table reference to SVG elements (for deleting elements)

### DIFF
--- a/src/Graphics/UI/driver.js
+++ b/src/Graphics/UI/driver.js
@@ -321,17 +321,15 @@ $.fn.livechange = function(ms,trigger){
     if( create[1] == "svg"){
       ns    = "http://www.w3.org/2000/svg";
       tag   = create[2];
-      elid_ = create[0] + ":" + create[2];
     }
     else {
       ns    = "http://www.w3.org/1999/xhtml";
       tag   = create[1];
-      elid_ = elid;
     }
-    if(el_table[elid_]) return el_table[elid_];
-    element         = document.createElementNS(ns, tag);
-    element.elid    = elid_;
-    el_table[elid_] = element;
+    if(el_table[elid]) return el_table[elid];
+    element        = document.createElementNS(ns, tag);
+    element.elid   = elid;
+    el_table[elid] = element;
     return element;
   }
  


### PR DESCRIPTION
It turns out that you couldn't delete SVG elements because the `elid` was a bit mangled (see patch.) Removing this mangling seemed to be the simplest way to fix it.
