### PR TITLE
Add support for “label” element and its “for” attribute

### DIFF
--- a/src/Graphics/UI/Threepenny/Attributes.hs
+++ b/src/Graphics/UI/Threepenny/Attributes.hs
@@ -10,7 +10,7 @@ module Graphics.UI.Threepenny.Attributes (
     background, base, bgcolor, border, bordercolor,
     cellpadding, cellspacing, checked_, class_, clear_, code_, codebase,
     color, cols, colspan, compact, content, coords,
-    enctype, face, frameborder, height, href, hspace, httpequiv,
+    enctype, face, for, frameborder, height, href, hspace, httpequiv,
     id_, ismap, lang, marginheight, marginwidth, maxlength, method, multiple,
     name, nohref, noresize, noshade, nowrap,
     rel, rev, rows, rowspan, rules,
@@ -86,6 +86,7 @@ content             =   strAttr "content"
 coords              =   strAttr "coords"
 enctype             =   strAttr "enctype"
 face                =   strAttr "face"
+for                 =   strAttr "for"
 frameborder         =   intAttr "frameborder"
 height              =   intAttr "height"
 href                =   strAttr "href"

--- a/src/Graphics/UI/Threepenny/Elements.hs
+++ b/src/Graphics/UI/Threepenny/Elements.hs
@@ -13,7 +13,7 @@ module Graphics.UI.Threepenny.Elements (
     dterm, emphasize, fieldset, font, form, frame, frameset,
     h1, h2, h3, h4, h5, h6, header, hr,
     img, image, input, italics,
-    keyboard, legend, li, link, map, meta, noframes, olist, option,
+    keyboard, label, legend, li, link, map, meta, noframes, olist, option,
     p, paragraph, param, pre,
     sample, select, small, source, span, strong, sub, sup,
     table, td, textarea, th, thebase,
@@ -101,6 +101,7 @@ image               = itag "img"
 input               = itag "input"
 italics             =  tag "i"
 keyboard            =  tag "kbd"
+label               =  tag "label"
 legend              =  tag "legend"
 li                  =  tag "li"
 link                =  tag "link"


### PR DESCRIPTION
I noticed that the `label` element (and its `for` attribute) were missing (see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label). They are very nice for checkboxes and radio buttons especially to have a larger clickable area.
