### PR TITLE
Fix build error on GHC 7.8

### DIFF
--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -345,7 +345,7 @@ fromJQueryProp name from to = mkReadWriteAttr get set
     get   el = fmap from $ callFunction $ ffi "$(%1).prop(%2)" el name
 
 -- | Turn a JavaScript object property @.prop = ...@ into an attribute.
-fromObjectProperty :: (ToJS a, FFI (JSFunction a)) => String -> Attr Element a
+fromObjectProperty :: (FromJS a, ToJS a, FFI (JSFunction a)) => String -> Attr Element a
 fromObjectProperty name = mkReadWriteAttr get set
     where
     set v el = runFunction  $ ffi ("%1." ++ name ++ " = %2") el v    

--- a/src/Graphics/UI/Threepenny/Internal.hs
+++ b/src/Graphics/UI/Threepenny/Internal.hs
@@ -10,7 +10,7 @@ module Graphics.UI.Threepenny.Internal (
     
     UI, runUI, liftIOLater, askWindow,
     
-    FFI, ToJS, JSFunction, JSObject, ffi,
+    FFI, FromJS, ToJS, JSFunction, JSObject, ffi,
     runFunction, callFunction, ffiExport, debug,
     
     Element, fromJSObject, getWindow,

--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -105,22 +105,22 @@ Library
   if flag(rebug)
       cpp-options:  -DREBUG
       ghc-options:  -O2 -threaded
-  build-depends:     base                   >= 4.3   && < 4.8
+  build-depends:     base                   >= 4.3   && < 4.9
                     ,aeson                  >= 0.6   && < 0.9
                     ,async                  == 2.0.*
                     ,attoparsec-enumerator  == 0.3.*
                     ,bytestring             >= 0.9.2 && < 0.11
                     ,containers             >= 0.4.2 && < 0.6
                     ,data-default           == 0.5.*
-                    ,deepseq                == 1.3.*
-                    ,filepath               == 1.3.*
+                    ,deepseq                == 1.4.*
+                    ,filepath               >= 1.3.0 && < 1.5.0
                     ,hashable               >= 1.1.0  && < 1.3
                     ,MonadCatchIO-transformers == 0.3.*
                     ,safe                   == 0.3.*
                     ,snap-server            == 0.9.*
                     ,snap-core              == 0.9.*
                     ,stm                    >= 2.2    && < 2.5
-                    ,template-haskell       >= 2.7.0  && < 2.10
+                    ,template-haskell       >= 2.7.0  && < 2.11
                     ,text                   >= 0.11   && < 1.3
                     ,time                   >= 1.4    && < 1.6
                     ,transformers           >= 0.3.0  && < 0.5


### PR DESCRIPTION
This change allows building on GHC 7.8 (I'm running 7.8.3). Not sure exactly how or why this worked before but doesn't anymore.