### PR TITLE
attoparsec-enumerator not needed.

### DIFF
--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -106,7 +106,6 @@ Library
   build-depends:     base                   >= 4.3   && < 4.9
                     ,aeson                  >= 0.7   && < 0.9
                     ,async                  == 2.0.*
-                    ,attoparsec-enumerator  == 0.3.*
                     ,bytestring             >= 0.9.2 && < 0.11
                     ,containers             >= 0.4.2 && < 0.6
                     ,data-default           == 0.5.*


### PR DESCRIPTION
I can't seem to find it's purpose anyway.