### PR TITLE
fixed documentation error: jsPort has type Maybe Int, not Int

### DIFF
--- a/src/Graphics/UI/Threepenny.hs
+++ b/src/Graphics/UI/Threepenny.hs
@@ -60,7 +60,7 @@ Additional static content is served from the @../wwwroot@ directory.
 > main :: IO ()
 > main = do
 >     startGUI defaultConfig
->         { jsPort       = 8023
+>         { jsPort       = Just 8023
 >         , jsStatic     = Just "../wwwroot"
 >         } setup
 
@@ -104,4 +104,3 @@ The libary comes with a
 
 
 -}
-


### PR DESCRIPTION
    main :: IO ()
    main = do
        startGUI defaultConfig
            { jsPort       = 8023
            , jsStatic     = Just "../wwwroot"
            } setup

in http://hackage.haskell.org/package/threepenny-gui-0.6.0.3/docs/Graphics-UI-Threepenny.html should be:

    main :: IO ()
    main = do
        startGUI defaultConfig
            { jsPort       = 8023
            , jsStatic     = Just "../wwwroot"
            } setup