### PR TITLE
fixed BarTab.hs example: UI.text instead of text

### DIFF
--- a/samples/BarTab.hs
+++ b/samples/BarTab.hs
@@ -23,13 +23,13 @@ setup w = do
     elResult <- UI.span
 
     inputs   <- liftIO $ newIORef []
-    
+
     -- functionality
     let
         displayTotal = void $ do
             xs <- mapM (get value) =<< liftIO (readIORef inputs)
-            element elResult # set text (showNumber . sum $ map readNumber xs)
-        
+            element elResult # set UI.text (showNumber . sum $ map readNumber xs)
+
         redoLayout :: UI ()
         redoLayout = void $ do
             layout <- mkLayout =<< liftIO (readIORef inputs)
@@ -44,16 +44,16 @@ setup w = do
             [UI.hr
             ,row [UI.span # set text "Sum: ", element elResult]
             ]
-        
+
         addInput :: UI ()
         addInput = do
             elInput <- UI.input # set value "0"
             on (domEvent "livechange") elInput $ \_ -> displayTotal
             liftIO $ modifyIORef inputs (elInput:)
-        
+
         removeInput :: UI ()
         removeInput = liftIO $ modifyIORef inputs (drop 1)
-    
+
     on UI.click elAdd    $ \_ -> addInput    >> redoLayout
     on UI.click elRemove $ \_ -> removeInput >> redoLayout
     addInput >> redoLayout
@@ -73,5 +73,5 @@ instance Num Number where
     fromInteger = pure . fromInteger
 
 readNumber :: String -> Number
-readNumber s = listToMaybe [x | (x,"") <- reads s]    
+readNumber s = listToMaybe [x | (x,"") <- reads s]
 showNumber   = maybe "--" show


### PR DESCRIPTION
On line 31

```
            element elResult # set UI.text (showNumber . sum $ map readNumber xs)
```

Works correctly, while

```
            element elResult # set text (showNumber . sum $ map readNumber xs)
```

makes that `<body>` tag is empty. I think instead of referring to [`Attributes.text_`](http://hackage.haskell.org/package/threepenny-gui-0.6.0.3/docs/Graphics-UI-Threepenny-Attributes.html#v:text_) it refers to [`Core.text`](http://hackage.haskell.org/package/threepenny-gui-0.6.0.3/docs/Graphics-UI-Threepenny-Core.html#v:text), which is a different function. Is that the source of the problem?
