### PR TITLE
Event unregistration

### DIFF
--- a/samples/DrumMachine.hs
+++ b/samples/DrumMachine.hs
@@ -46,7 +46,7 @@ setup w = void $ do
     timer <- UI.timer # set UI.interval (bpm2ms defaultBpm)
     eBeat <- accumE (0::Int) $
         (\beat -> (beat + 1) `mod` (beats * bars)) <$ UI.tick timer
-    onEvent eBeat $ \beat -> do
+    void . onEvent eBeat $ \beat -> do
         -- display beat count
         element elTick # set text (show $ beat + 1)
         -- play corresponding sounds

--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -232,16 +232,16 @@ grid mrows = do
 --
 -- > on click element $ \_ -> ...
 on :: (element -> Event a) -> element -> (a -> UI void) -> UI ()
-on f x = onEvent (f x)
+on f x = void . onEvent (f x)
 
 -- | Register an 'UI' action to be executed whenever the 'Event' happens.
 -- 
 -- FIXME: Should be unified with 'on'?
-onEvent :: Event a -> (a -> UI void) -> UI ()
+onEvent :: Event a -> (a -> UI void) -> UI (UI ())
 onEvent e h = do
     window <- askWindow
-    liftIO $ register e (void . runUI window . h)
-    return ()
+    unregister <- liftIO $ register e (void . runUI window . h)
+    return (liftIO unregister)
 
 -- | Execute a 'UI' action whenever a 'Behavior' changes.
 -- Use sparingly, it is recommended that you use 'sink' instead.

--- a/src/Reactive/Threepenny.hs
+++ b/src/Reactive/Threepenny.hs
@@ -130,7 +130,6 @@ register :: Event a -> Handler a -> IO (IO ())
 register e h = do
     p <- at (unE e)     -- evaluate the memoized action
     Prim.addHandler p h
-    return $ return ()  -- FIXME
 
 -- | Register an event 'Handler' for a 'Behavior'.
 -- All registered handlers will be called whenever the behavior changes.

--- a/src/Reactive/Threepenny/PulseLatch.hs
+++ b/src/Reactive/Threepenny/PulseLatch.hs
@@ -161,7 +161,7 @@ accumL a p1 = do
     -- register handler to update latch
     uid <- newUnique
     let handler = whenPulse p2 $ (writeIORef latch $!)
-    addHandlerP p2 ((uid, DoLatch), handler)
+    void $ addHandlerP p2 ((uid, DoLatch), handler)
     
     return (l1,p2)
 
@@ -191,7 +191,7 @@ test = do
     (l1,_) <- accumL 0 p2
     let l2 =  mapL const l1
     p3     <- applyP l2 p1
-    addHandler p3 print
+    void $ addHandler p3 print
     return fire
 
 test_recursion1 :: IO (IO ())
@@ -201,5 +201,5 @@ test_recursion1 = mdo
     p3      <- mapP (const (+1)) p2
     ~(l1,_) <- accumL (0::Int) p3
     let l2  =  mapL const l1
-    addHandler p2 print
+    void $ addHandler p2 print
     return $ fire ()

--- a/src/Reactive/Threepenny/PulseLatch.hs
+++ b/src/Reactive/Threepenny/PulseLatch.hs
@@ -35,7 +35,7 @@ cacheEval :: EvalP (Maybe a) -> Build (Pulse a)
 cacheEval e = do
     key <- Vault.newKey
     return $ Pulse
-        { addHandlerP = \_ -> return ()
+        { addHandlerP = \_ -> return (return ())
         , evalP       = do
             vault <- Monad.get
             case Vault.lookup key vault of
@@ -48,7 +48,7 @@ cacheEval e = do
 
 -- Add a dependency to a pulse, for the sake of keeping track of dependencies.
 dependOn :: Pulse a -> Pulse b -> Pulse a
-dependOn p q = p { addHandlerP = \h -> addHandlerP p h >> addHandlerP q h }
+dependOn p q = p { addHandlerP = \h -> (>>) <$> addHandlerP p h <*> addHandlerP q h }
 
 -- Execute an action when the pulse occurs
 whenPulse :: Pulse a -> (a -> IO ()) -> Handler
@@ -69,12 +69,10 @@ newPulse = do
     
     let
         -- add handler to map
-        addHandlerP :: ((Unique, Priority), Handler) -> Build ()
+        addHandlerP :: ((Unique, Priority), Handler) -> Build (IO ())
         addHandlerP (uid,m) = do
-            handlers <- readIORef handlersRef
-            case Map.lookup uid handlers of
-                Just _  -> return ()
-                Nothing -> writeIORef handlersRef $ Map.insert uid m handlers
+            modifyIORef' handlersRef (Map.insert uid m)
+            return $ modifyIORef' handlersRef (Map.delete uid)
         
         -- evaluate all handlers attached to this input pulse
         fireP a = do
@@ -90,9 +88,7 @@ newPulse = do
     return (Pulse {..}, fireP)
 
 -- | Register a handler to be executed whenever a pulse occurs.
---
--- FIXME: Cannot unregister a handler again.
-addHandler :: Pulse a -> (a -> IO ()) -> Build ()
+addHandler :: Pulse a -> (a -> IO ()) -> Build (IO ())
 addHandler p f = do
     uid <- newUnique
     addHandlerP p ((uid, DoIO), whenPulse p f)
@@ -108,7 +104,7 @@ readLatch = readL
 -- | Create a new pulse that never occurs.
 neverP :: Pulse a
 neverP = Pulse
-    { addHandlerP = const $ return ()
+    { addHandlerP = const $ return (return ())
     , evalP       = return Nothing
     }
 

--- a/src/Reactive/Threepenny/Types.hs
+++ b/src/Reactive/Threepenny/Types.hs
@@ -16,7 +16,7 @@ type Handler  = EvalP (IO ())
 data Priority = DoLatch | DoIO deriving (Eq,Show,Ord,Enum)
 
 data Pulse a = Pulse
-    { addHandlerP :: ((Unique, Priority), Handler) -> Build ()
+    { addHandlerP :: ((Unique, Priority), Handler) -> Build (IO ())
     , evalP       :: EvalP (Maybe a)
     }
 


### PR DESCRIPTION
This PR adds a straightforward implementation of event unregistration as mentioned in #122. I need this for a GUI library I'm building on top of Threepenny.

The `onEvent` function now has a different signature so that could break code but I left `on` unchanged, as I consider the latter to be the more 'higher level' function that is probably used more frequently, without need for unregistration.