### PR TITLE
mouse coordinates only using pageX and pageY

### DIFF
--- a/js/lib.js
+++ b/js/lib.js
@@ -36,10 +36,7 @@ Haskell.bind = function (el, eventType, fun) {
     });
   } else if(eventType.match('contextmenu|mousemove|mousedown|mouseup')) {
     $(el).bind(eventType, function(e) {
-      var offset = $(this).offset();
-      var x      = e.pageX - offset.left;
-      var y      = e.pageY - offset.top;
-      fun([x, y]);
+      fun([e.pageX, e.pageY]);
     });
   } else if(eventType.match('keydown|keyup')) {
     $(el).bind(eventType, function(e) {

--- a/src/Graphics/UI/Threepenny/Events.hs
+++ b/src/Graphics/UI/Threepenny/Events.hs
@@ -53,7 +53,7 @@ hover = silence . domEvent "mouseenter"
 -- | Event that periodically occurs while the mouse is moving over an element.
 --
 -- The event value represents the mouse coordinates
--- relative to the upper left corner of the element.
+-- relative to the upper left corner of the display.
 --
 -- Note: The @<body>@ element responds to mouse move events,
 -- but only in the area occupied by actual content,


### PR DESCRIPTION
I have attached images showing the previous behaviour and the updated behaviour in both Chrome and Electron.

The code used displays a `div` with text "foo" at the coordinates where the right-click took place. In each case the right click actually took place on the "s" of "Proofs".

**Electron before**
![electron-err](https://cloud.githubusercontent.com/assets/6631452/23309630/5de7b4da-faa7-11e6-97af-5d1476e2a6ac.png)

**Electron after**
![electron-fix](https://cloud.githubusercontent.com/assets/6631452/23309640/6666cf10-faa7-11e6-89d9-41994b91a352.png)

**Chrome before**
![chrome-err](https://cloud.githubusercontent.com/assets/6631452/23309644/6b87c7b0-faa7-11e6-98f3-7d07ed4d4421.png)

**Chrome after**
![chrome-fix](https://cloud.githubusercontent.com/assets/6631452/23309654/70e24d70-faa7-11e6-8cd2-e8113950eaa3.png)

