### PR TITLE
Expose the underlying JSObject of an Element.

### DIFF
--- a/src/Foreign/JavaScript.hs
+++ b/src/Foreign/JavaScript.hs
@@ -7,7 +7,8 @@ module Foreign.JavaScript (
     -- a web browser and allows you to execute arbitrary JavaScript code on it.
     --
     -- NOTE: This module is used internally by the "Graphics.UI.Threepenny"
-    -- library, but the types are /not/ compatible.
+    -- library, but the types are /not/ compatible directly
+    -- (although some escape hatches are provided).
     -- Use "Foreign.JavaScript" only if you want to roll your own
     -- interface to the web browser.
 

--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -51,7 +51,7 @@ module Graphics.UI.Threepenny.Core (
     ToJS, FFI,
     JSFunction, ffi, runFunction, callFunction,
     CallBufferMode(..), setCallBufferMode, flushCallBuffer,
-    ffiExport,
+    ffiExport, ffiExport',
 
     -- * Internal and oddball functions
     fromJQueryProp,

--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -19,7 +19,7 @@ module Graphics.UI.Threepenny.Core (
 
     -- * DOM elements
     -- | Create and manipulate DOM elements.
-    Element(toJSObject), getWindow, mkElement, mkElementNamespace, delete,
+    Element, toJSObject, getWindow, mkElement, mkElementNamespace, delete,
         string,
         getHead, getBody,
         (#+), children, text, html, attr, style, value,

--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -19,7 +19,7 @@ module Graphics.UI.Threepenny.Core (
 
     -- * DOM elements
     -- | Create and manipulate DOM elements.
-    Element, toJSObject, getWindow, mkElement, mkElementNamespace, delete,
+    Element, getWindow, mkElement, mkElementNamespace, delete,
         string,
         getHead, getBody,
         (#+), children, text, html, attr, style, value,
@@ -52,7 +52,8 @@ module Graphics.UI.Threepenny.Core (
     JSFunction, ffi, runFunction, callFunction,
     CallBufferMode(..), setCallBufferMode, flushCallBuffer,
     ffiExport,
-
+    -- ** Internals
+    toJSObject, liftJSWindow,
     -- * Internal and oddball functions
     fromJQueryProp,
 

--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -19,7 +19,7 @@ module Graphics.UI.Threepenny.Core (
 
     -- * DOM elements
     -- | Create and manipulate DOM elements.
-    Element, getWindow, mkElement, mkElementNamespace, delete,
+    Element(toJSObject), getWindow, mkElement, mkElementNamespace, delete,
         string,
         getHead, getBody,
         (#+), children, text, html, attr, style, value,

--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -51,7 +51,7 @@ module Graphics.UI.Threepenny.Core (
     ToJS, FFI,
     JSFunction, ffi, runFunction, callFunction,
     CallBufferMode(..), setCallBufferMode, flushCallBuffer,
-    ffiExport, ffiExport',
+    ffiExport,
 
     -- * Internal and oddball functions
     fromJQueryProp,

--- a/src/Graphics/UI/Threepenny/Internal.hs
+++ b/src/Graphics/UI/Threepenny/Internal.hs
@@ -15,7 +15,7 @@ module Graphics.UI.Threepenny.Internal (
     CallBufferMode(..), setCallBufferMode, flushCallBuffer,
     ffiExport, debug, timestamp,
 
-    Element, fromJSObject, getWindow,
+    Element(toJSObject), fromJSObject, getWindow,
     mkElementNamespace, mkElement, delete, appendChild, clearChildren,
 
     EventData, domEvent, unsafeFromJSON,

--- a/src/Graphics/UI/Threepenny/Internal.hs
+++ b/src/Graphics/UI/Threepenny/Internal.hs
@@ -8,7 +8,7 @@ module Graphics.UI.Threepenny.Internal (
     Window, disconnect,
     startGUI, loadFile, loadDirectory,
 
-    UI, runUI, MonadUI(..), liftIOLater, askWindow,
+    UI, runUI, MonadUI(..), liftIOLater, askWindow, liftJSWindow,
 
     FFI, FromJS, ToJS, JSFunction, JSObject, ffi,
     runFunction, callFunction,
@@ -104,7 +104,7 @@ type Events = String -> RB.Event JSON.Value
 type Children = Foreign.RemotePtr ()
 
 data Element = Element
-    { toJSObject  :: JS.JSObject -- ^ The corresponding JavaScript object.
+    { toJSObject  :: JS.JSObject -- ^ Access to the primitive 'JS.JSObject' for roll-your-own foreign calls.
     , elEvents    :: Events      -- ^ FRP event mapping
     , elChildren  :: Children    -- ^ The children of this element
     , elWindow    :: Window      -- ^ Window in which the element was created
@@ -279,6 +279,8 @@ class (Monad m) => MonadUI m where
 instance MonadUI UI where
     liftUI = id
 
+-- | Access to the primitive 'JS.Window' object,
+--   for roll-your-own JS foreign calls.
 liftJSWindow :: (JS.Window -> IO a) -> UI a
 liftJSWindow f = askWindow >>= liftIO . f . jsWindow
 

--- a/src/Graphics/UI/Threepenny/Internal.hs
+++ b/src/Graphics/UI/Threepenny/Internal.hs
@@ -13,7 +13,7 @@ module Graphics.UI.Threepenny.Internal (
     FFI, FromJS, ToJS, JSFunction, JSObject, ffi,
     runFunction, callFunction,
     CallBufferMode(..), setCallBufferMode, flushCallBuffer,
-    ffiExport, debug, timestamp,
+    ffiExport, ffiExport', debug, timestamp,
 
     Element(toJSObject), fromJSObject, getWindow,
     mkElementNamespace, mkElement, delete, appendChild, clearChildren,
@@ -352,7 +352,7 @@ flushCallBuffer = liftJSWindow $ \w -> JS.flushCallBuffer w
 -- | Export the given Haskell function so that it can be called
 -- from JavaScript code.
 --
--- NOTE: At the moment, the 'JSObject' representing the exported function
+-- NOTE: The JSObject returned by this function
 -- will be referenced by the browser 'Window' in which it was created,
 -- preventing garbage collection until this browser 'Window' is disconnected.
 --
@@ -360,15 +360,23 @@ flushCallBuffer = liftJSWindow $ \w -> JS.flushCallBuffer w
 -- but it also means that the Haskell runtime has no way to detect
 -- early when it is no longer needed.
 --
--- In contrast, if you use the function 'domEvent' to register an
--- event handler to an 'Element',
+-- In contrast, if you use the variant 'ffiExport\'',
 -- then the handler will be garbage collected
--- as soon as the associated 'Element' is garbage collected.
+-- unless the caller keeps it alive using 'addReachable'.
+
 ffiExport :: JS.IsHandler a => a -> UI JSObject
 ffiExport fun = liftJSWindow $ \w -> do
     handlerPtr <- JS.exportHandler w fun
     Foreign.addReachable (JS.root w) handlerPtr
     return handlerPtr
+-- | Export the given Haskell function so that it can be called
+-- from JavaScript code.
+--
+-- NOTE: The caller is responsible for ensuring the JSObject returned
+-- by this function is kept alive using 'addReachable'.
+-- Otherwise it may be collected by the Javascript side garbage collector.
+ffiExport' :: JS.IsHandler a => a -> UI JSObject
+ffiExport' fun = liftJSWindow (`JS.exportHandler` fun)
 
 -- | Print a message on the client console if the client has debugging enabled.
 debug :: String -> UI ()

--- a/src/Graphics/UI/Threepenny/Internal.hs
+++ b/src/Graphics/UI/Threepenny/Internal.hs
@@ -104,10 +104,10 @@ type Events = String -> RB.Event JSON.Value
 type Children = Foreign.RemotePtr ()
 
 data Element = Element
-    { toJSObject  :: JS.JSObject -- corresponding JavaScript object
-    , elEvents    :: Events      -- FRP event mapping
-    , elChildren  :: Children    -- The children of this element
-    , elWindow    :: Window      -- Window in which the element was created
+    { toJSObject  :: JS.JSObject -- ^ The corresponding JavaScript object.
+    , elEvents    :: Events      -- ^ FRP event mapping
+    , elChildren  :: Children    -- ^ The children of this element
+    , elWindow    :: Window      -- ^ Window in which the element was created
     } deriving (Typeable)
 
 instance ToJS Element where
@@ -360,20 +360,20 @@ flushCallBuffer = liftJSWindow $ \w -> JS.flushCallBuffer w
 -- but it also means that the Haskell runtime has no way to detect
 -- early when it is no longer needed.
 --
--- In contrast, if you use the variant 'ffiExport\'',
+-- In contrast, if you use the variant 'ffiExport'',
 -- then the handler will be garbage collected
 -- unless the caller keeps it alive using 'addReachable'.
-
 ffiExport :: JS.IsHandler a => a -> UI JSObject
 ffiExport fun = liftJSWindow $ \w -> do
     handlerPtr <- JS.exportHandler w fun
     Foreign.addReachable (JS.root w) handlerPtr
     return handlerPtr
+
 -- | Export the given Haskell function so that it can be called
 -- from JavaScript code.
 --
 -- NOTE: The caller is responsible for ensuring the JSObject returned
--- by this function is kept alive using 'addReachable'.
+-- by this function is kept alive using 'Foreign.addReachable'.
 -- Otherwise it may be collected by the Javascript side garbage collector.
 ffiExport' :: JS.IsHandler a => a -> UI JSObject
 ffiExport' fun = liftJSWindow (`JS.exportHandler` fun)


### PR DESCRIPTION
As discussed, this will enable easier management of custom JSObject lifetimes, as illustrated by the new version of ffiExport.