### PR TITLE
Add support for synthetic events (CustomEvent)

### DIFF
--- a/js/lib.js
+++ b/js/lib.js
@@ -48,7 +48,7 @@ Haskell.bind = function (el, eventType, fun) {
     });
   } else {
     $(el).bind(eventType, function(e) {
-      fun(e.which ? [e.which.toString()] : []);
+      fun(e.which ? [e.which.toString()] : e.detail || []);
       return true;
     });
   }


### PR DESCRIPTION
Synthetic events use `CustomEvent()`, which contains a customizable `detail` attribute.  This PR allows that attribute to be passed to the Haskell side, allowing one to, say, use:

```haskell
on (domEvent "myEvent") elm $ ...
```

on the Haskell side, and:

```javascript
var ev = new CustomEvent("myEvent", { detail: ... });
elm.dispatchEvent(ev);
```

on the JavaScript side.

Cf. <https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent>