### PR TITLE
Allow file-embed-0.0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `getCookies` function that retrieves the cookies sent with the HTTP request when the browser window connects (to the websocket). [#137][]
 * Allow Electron process to be accessed from JavaScript FFI. [#200][] This means that Threepenny is now more useful when used with the [Electron][] framework, see [doc/electron.md](doc/electron.md) for more information on that.
+* Bump dependencies to allow `file-embed` 0.0.10.1
 
   [#137]: https://github.com/HeinrichApfelmus/threepenny-gui/issues/137
   [#200]: https://github.com/HeinrichApfelmus/threepenny-gui/issues/200

--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -116,7 +116,7 @@ Library
                     ,deepseq                >= 1.3.0 && < 1.5
                     ,exceptions             >= 0.6   && < 0.9
                     ,filepath               >= 1.3.0 && < 1.5.0
-                    ,file-embed             == 0.0.10
+                    ,file-embed             >= 0.0.10 && < 0.1
                     ,hashable               >= 1.1.0 && < 1.3
                     ,safe                   == 0.3.*
                     ,snap-server            >= 0.9.0 && < 1.1


### PR DESCRIPTION
@HeinrichApfelmus Do you mind if I release v0.8.2.0 including the `getCookies` addition? Otherwise I'd make a v0.8.1.1 only for the version bump.