### PR TITLE
Added runhaskell-script for Windows

### DIFF
--- a/samples/runhaskell.cmd
+++ b/samples/runhaskell.cmd
@@ -1,0 +1,14 @@
+IF EXIST "../.cabal-sandbox" (
+  ghc -i../src ^
+    -no-user-package-db ^
+    -package-db ../.cabal-sandbox/*-packages.conf.d ^
+    -DSAMPLES "%* -e main
+) ELSE (
+  IF EXIST ../stack.yaml (
+  stack --stack-yaml "../stack.yaml" exec ^
+    ghc -- -i../src ^
+    -DSAMPLES "%*" -e main
+  ) ELSE (
+  ghc -DSAMPLES "%*" -e main
+  )
+)


### PR DESCRIPTION
A Windows-CMD-port of the runhaskell bash-script. Tested with stack.

Using this batch running the examples as described in the README works natively on Windows (given stack has been installed before) and the command `./runhaskell` is replaced by `runhaskell.cmd`.
