### PR TITLE
support https (wss)

### DIFF
--- a/js/comm.js
+++ b/js/comm.js
@@ -15,7 +15,7 @@
 Haskell.createWebSocket = function (url0, receive) {
   var that = {};
   var optReloadOnDisconnect = false;
-  var url  = 'ws:' + url0.slice(5) + '/websocket/';
+  var url  = 'ws' + url0.slice(4) + '/websocket/';
   var ws   = new WebSocket(url);
   
   // Close WebSocket when the browser window is closed.


### PR DESCRIPTION
When using https secure websockets (wss) have to be used.
Also the slice(5) doesn't work properly for https as it would include the colon.