### PR TITLE
Invoke compatibility mode of IE11 for jQuery v3.2.1

### DIFF
--- a/js/index.html
+++ b/js/index.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+
   <title></title>
   <link rel="stylesheet" type="text/css" href="haskell.css"/>
 


### PR DESCRIPTION
See https://forum.jquery.com/topic/ie-11-issue-d-addeventlistener-domcontentloaded-s-with-jquery-3-2-1

Without this patch `d.addEventListener("DOMContentLoaded",S);` fails. This call is in jQuery.

Maybe upgrading to a recent jQuery version (e.g. [3.3.1](https://github.com/jquery/jquery/releases)) would also work, but I shied away from that for now.