### PR TITLE
Add bulk attribute setter operator

### DIFF
--- a/src/Graphics/UI/Threepenny/Core.hs
+++ b/src/Graphics/UI/Threepenny/Core.hs
@@ -37,7 +37,7 @@ module Graphics.UI.Threepenny.Core (
 
     -- * Attributes
     -- | For a list of predefined attributes, see "Graphics.UI.Threepenny.Attributes".
-    (#), (#.),
+    (#), (#.), (#=),
     Attr, WriteAttr, ReadAttr, ReadWriteAttr(..),
     set, sink, get, mkReadWriteAttr, mkWriteAttr, mkReadAttr,
     bimapAttr, fromObjectProperty,
@@ -284,6 +284,10 @@ infixl 8 #.
 -- | Convenient combinator for setting the CSS class on element creation.
 (#.) :: UI Element -> String -> UI Element
 (#.) mx s = mx # set (attr "class") s
+
+-- | Convenient combinator for bulk setting of attributes on element creation.
+(#=) :: Foldable t => UI x -> t (ReadWriteAttr x i o, i) -> UI x
+(#=) e = ($ e) . foldl (\f p -> f . uncurry set p) id
 
 -- | Attributes can be 'set' and 'get'.
 type Attr x a = ReadWriteAttr x a a


### PR DESCRIPTION
This allows us to write
``` haskell
SVG.marker #=
    [ (SVG.id, "arrow")
    , (SVG.viewBox, "0 0 10 10")
    , (SVG.refx, "5")
    , (SVG.refy, "5")
    , (SVG.markerWidth, "6")
    , (SVG.markerHeight, "6")
    , (SVG.orient, "auto")]
           #+ [SVG.path # set SVG.d "M0 0L10 5L0 10z"]
```
Importantly, the attribute list can come from any `Foldable` container.