### PR TITLE
Mouse events return Doubles (#238)

### DIFF
--- a/src/Graphics/UI/Threepenny/Events.hs
+++ b/src/Graphics/UI/Threepenny/Events.hs
@@ -43,7 +43,7 @@ click :: Element -> Event ()
 click = silence . domEvent "click"
 
 -- | Context menu event.
-contextmenu :: Element -> Event (Int,Int)
+contextmenu :: Element -> Event (Double,Double)
 contextmenu = fmap readCoordinates . domEvent "contextmenu"
 
 -- | Mouse enters an element.
@@ -58,21 +58,32 @@ hover = silence . domEvent "mouseenter"
 -- Note: The @<body>@ element responds to mouse move events,
 -- but only in the area occupied by actual content,
 -- not the whole browser window.
-mousemove :: Element -> Event (Int,Int)
+mousemove :: Element -> Event (Double,Double)
 mousemove = fmap readCoordinates . domEvent "mousemove"
 
-readCoordinates :: EventData -> (Int,Int)
+-- NB: we return @Double@s rather than @Int@s here because
+-- mouse events' return types have been redefined from @long@
+-- to @double@ in the CSS Object Model View Model working draft,
+-- which has started to be adopted by browsers.
+-- See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent#Specifications
+-- and https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/pageX
+--
+-- Similarly, we rely on jQuery's @.offset()@ to return
+-- coordinates relative to the upper left corner of the
+-- element, and this may return fractional data.
+-- https://api.jquery.com/offset/
+readCoordinates :: EventData -> (Double,Double)
 readCoordinates json = (x,y)
     where [x,y] = unsafeFromJSON json
 
 -- | Mouse down event.
 -- The mouse coordinates are relative to the element.
-mousedown :: Element -> Event (Int,Int)
+mousedown :: Element -> Event (Double,Double)
 mousedown = fmap readCoordinates . domEvent "mousedown"
 
 -- | Mouse up event.
 -- The mouse coordinates are relative to the element.
-mouseup :: Element -> Event (Int,Int)
+mouseup :: Element -> Event (Double,Double)
 mouseup = fmap readCoordinates . domEvent "mouseup"
 
 -- | Mouse leaving an element.


### PR DESCRIPTION
Note that this is a breaking change in our API which is necessary to
avoid crashing in some circumstances (for instance having a mousedown
event on some SVG element with Firefox 76)

This fixes #238 