### PR TITLE
Allow bytestring 0.11

### DIFF
--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -112,7 +112,7 @@ Library
   build-depends:     base                   >= 4.8   && < 4.15
                     ,aeson                  (>= 0.7 && < 0.10) || == 0.11.* || (>= 1.0 && < 1.6)
                     ,async                  >= 2.0   && < 2.3
-                    ,bytestring             >= 0.9.2 && < 0.11
+                    ,bytestring             >= 0.9.2 && < 0.12
                     ,containers             >= 0.4.2 && < 0.7
                     ,data-default           >= 0.5.0 && < 0.8
                     ,deepseq                >= 1.3.0 && < 1.5


### PR DESCRIPTION
I've tested this locally with `cabal build --constraint="bytestring>=0.11" --allow-newer=bytestring`.