### PR TITLE
added check for https:// to decide whether to use ssl-encrypted websockets

### DIFF
--- a/js/comm.js
+++ b/js/comm.js
@@ -15,7 +15,8 @@
 Haskell.createWebSocket = function (url0, receive) {
   var that = {};
   var optReloadOnDisconnect = false;
-  var url  = 'ws:' + url0.slice(5) + '/websocket/';
+  var connectType = location.protocol === 'https:' ? 'wss' : 'ws'
+  var url  = connectType + url0.slice(5) + '/websocket/';
   var ws   = new WebSocket(url);
   
   // Close WebSocket when the browser window is closed.

--- a/js/comm.js
+++ b/js/comm.js
@@ -15,7 +15,7 @@
 Haskell.createWebSocket = function (url0, receive) {
   var that = {};
   var optReloadOnDisconnect = false;
-  var connectType = location.protocol === 'https:' ? 'wss' : 'ws'
+  var connectType = location.protocol === 'https:' ? 'wss' : 'ws';
   var url  = connectType + url0.slice(5) + '/websocket/';
   var ws   = new WebSocket(url);
   


### PR DESCRIPTION
Hello,

I hope you receive this well.  The Cardano RTview web interface is using your library threepenny-gui library for their UI and I discovered that some code in your javascript doesn't account for connecting to websockets over SSL.  I added a fix to the javascript to account for if it's being loaded over SSL or not.

Here's the initial issue this fixes: https://github.com/input-output-hk/cardano-rt-view/issues/124