### PR TITLE
HashMap Performance Fix

### DIFF
--- a/src/Reactive/Threepenny/Types.hs
+++ b/src/Reactive/Threepenny/Types.hs
@@ -20,7 +20,7 @@ data Pulse a = Pulse
     , evalP       :: EvalP (Maybe a)
     }
 
-instance Hashable Priority where hashWithSalt _ = fromEnum
+instance Hashable Priority where hashWithSalt = (. fromEnum) . (*)
 
 data Latch a = Latch { readL :: EvalL a }
 


### PR DESCRIPTION
The salt shouldn't be ignored since the HashMap has poor performance when adding new elements (as used [here](https://github.com/HeinrichApfelmus/threepenny-gui/blob/master/src/Reactive/Threepenny/PulseLatch.hs#L74)) otherwise. Composed types like tuples are usually hashed via chaining the elements' hashes through the salt (cf. [here](https://github.com/haskell-unordered-containers/hashable/blob/master/src/Data/Hashable/Class.hs#L593)).

I used the following code for testing:
```haskell
import qualified Graphics.UI.Threepenny as UI
import Graphics.UI.Threepenny.Core

main :: IO ()
main = startGUI defaultConfig $ \w ->
  sequence_ $ replicate 1000 $ do
    x <- string "x"
    -- insert a new element into the hashmap
    on UI.click x $ const $ return () 
    -- make the progress visible
    getBody w 
      # set style [("display","flex"), ("flex-wrap","wrap")]
      #+ [ element x ]
```