### PR TITLE
Allow transformers 0.6

### DIFF
--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -128,7 +128,7 @@ Library
                     ,stm                    >= 2.2    && < 2.6
                     ,template-haskell       >= 2.7.0  && < 2.20
                     ,text                   >= 0.11   && < 2.1
-                    ,transformers           >= 0.3.0  && < 0.6
+                    ,transformers           >= 0.3.0  && < 0.7
                     ,unordered-containers   == 0.2.*
                     ,websockets             (>= 0.8    && < 0.12.5) || (> 0.12.5.0 && < 0.13)
                     ,websockets-snap        >= 0.8    && < 0.11


### PR DESCRIPTION
https://hackage.haskell.org/package/transformers-0.6.0.0/changelog

---

Build command as of 2022-05-10:

```
cabal build --constraint 'transformers >= 0.6' -w ghc-8.10 --allow-newer=websockets-snap:mtl,io-streams:transformers,snap-server:mtl,io-streams-haproxy:transformers,snap-core:mtl,snap-core:transformers
```

Blocked on:

* [x] https://github.com/haskell/mtl/issues/88 (via `websockets-snap`)
* [x] https://github.com/snapframework/snap-server/issues/144
* [x] https://github.com/ekmett/exceptions/issues/82
* [x] https://github.com/snapframework/snap-core/issues/313

Bounds only (I guess):

* [x] https://github.com/snapframework/io-streams/issues/80