### PR TITLE
Allow building with GHC 9.2, update CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20210912
+# version: 0.13.20211030
 #
-# REGENDATA ("0.13.20210912",["--ghcup-jobs-jobs=>= 8","--branches=master","github","threepenny-gui.cabal"])
+# REGENDATA ("0.13.20211030",["--ghcup-jobs-jobs=>= 8","--branches=master","github","threepenny-gui.cabal"])
 #
 name: Haskell-CI
 on:
@@ -30,6 +30,16 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.2.1
+            compilerKind: ghc
+            compilerVersion: 9.2.1
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.0.1
+            compilerKind: ghc
+            compilerVersion: 9.0.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
             compilerVersion: 8.10.7
@@ -73,18 +83,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.16.2/x86_64-linux-ghcup-0.1.16.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.0.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.16.2/x86_64-linux-ghcup-0.1.16.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.0.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -102,13 +112,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')

--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -35,6 +35,8 @@ Tested-With:         GHC == 7.10.3
                     ,GHC == 8.6.5
                     ,GHC == 8.8.4
                     ,GHC == 8.10.7
+                    ,GHC == 9.0.1
+                    ,GHC == 9.2.1
 
 Extra-Source-Files:  CHANGELOG.md
                     ,README.md
@@ -109,7 +111,7 @@ Library
   if flag(rebug)
       cpp-options:  -DREBUG
       ghc-options:  -O2
-  build-depends:     base                   >= 4.8   && < 4.16
+  build-depends:     base                   >= 4.8   && < 4.17
                     ,aeson                  (>= 0.7 && < 0.10) || == 0.11.* || (>= 1.0 && < 2.1)
                     ,async                  >= 2.0   && < 2.3
                     ,bytestring             >= 0.9.2 && < 0.12
@@ -124,7 +126,7 @@ Library
                     ,snap-server            >= 0.9.0 && < 1.2
                     ,snap-core              >= 0.9.0 && < 1.1
                     ,stm                    >= 2.2    && < 2.6
-                    ,template-haskell       >= 2.7.0  && < 2.18
+                    ,template-haskell       >= 2.7.0  && < 2.19
                     ,text                   >= 0.11   && < 1.3
                     ,transformers           >= 0.3.0  && < 0.6
                     ,unordered-containers   == 0.2.*


### PR DESCRIPTION
This is still blocked on a large number of dependencies.

Incantation as of 2022-03-14:
```
cabal build --allow-newer=snap-server:base,io-streams-haproxy:base,snap-server:bytestring,snap-server:attoparsec,websockets-snap:bytestring,snap-server:time,io-streams-haproxy:attoparsec,io-streams-haproxy:bytestring
```

Upstream issues:

* [x] https://github.com/haskell/aeson/issues/885.
* [x] https://github.com/snapframework/snap-core/issues/311 (~~needs release~~)
* [x] https://github.com/snapframework/snap-server/issues/142
* [x] https://github.com/snapframework/io-streams-haproxy/pull/21
* [ ] https://github.com/snapframework/snap-server/issues/148
* [ ] https://github.com/snapframework/io-streams-haproxy/issues/25