### PR TITLE
Allow text-2.0

### DIFF
--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -125,7 +125,7 @@ Library
                     ,snap-core              >= 0.9.0 && < 1.1
                     ,stm                    >= 2.2    && < 2.6
                     ,template-haskell       >= 2.7.0  && < 2.18
-                    ,text                   >= 0.11   && < 1.3
+                    ,text                   >= 0.11   && < 2.1
                     ,transformers           >= 0.3.0  && < 0.6
                     ,unordered-containers   == 0.2.*
                     ,websockets             (>= 0.8    && < 0.12.5) || (> 0.12.5.0 && < 0.13)


### PR DESCRIPTION
https://hackage.haskell.org/package/text-2.0/changelog

---

I'm currently building this with

```
cabal build --constraint 'text >= 2' --allow-newer=io-streams:text,websockets:text,snap-server:text,blaze-builder:text,snap-core:text,aeson:text,uuid-types:text,snap-core:hashable,scientific:text,text-short:text,strict:text,snap-server:attoparsec,io-streams-haproxy:attoparsec,snap-core:attoparsec
```

This is mainly blocked on `aeson`, which will need a new release. The other dependencies already _build_ fine.

---

BTW: Merry Christmas, @HeinrichApfelmus and every else who sees this! :)