### PR TITLE
Allow vector-0.13

### DIFF
--- a/threepenny-gui.cabal
+++ b/threepenny-gui.cabal
@@ -131,7 +131,7 @@ Library
                     ,websockets             (>= 0.8    && < 0.12.5) || (> 0.12.5.0 && < 0.13)
                     ,websockets-snap        >= 0.8    && < 0.11
                     ,vault                  == 0.3.*
-                    ,vector                 >= 0.10   && < 0.13
+                    ,vector                 >= 0.10   && < 0.14
   if impl(ghc >= 8.0)
       ghc-options: -Wcompat -Wnoncanonical-monad-instances
   default-language: Haskell2010


### PR DESCRIPTION
https://hackage.haskell.org/package/vector-0.13.0.0/changelog

---

Blocked on:

* [x] https://github.com/snapframework/io-streams/issues/82 (needs release)

Current incantation:

```
cabal build --constraint 'vector >= 0.13' -w ghc-8.10 --allow-newer=io-streams:vector,snap-server:vector,snap-core:vector,snap-server:attoparsec
```