### PR TITLE
Make `javascript-ffi-threepenny` work with MicroHs

### DIFF
--- a/lib/javascript-ffi-threepenny/Test.html
+++ b/lib/javascript-ffi-threepenny/Test.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>MicroHs and JavaScript</title>
+
+    <!-- See https://stackoverflow.com/a/37480521  -->
+    <script>if (typeof module === 'object') {window.module = module; module = undefined;}</script>
+    <script src="js/lib/jquery.js"></script>
+    <script>var Haskell = {};</script>
+    <script src="js/ffi-microhs.js"></script>
+    <script src="js/lib.js"></script>
+    <script>if (window.module) module = window.module;</script>
+
+    <script type="text/javascript" charset="utf-8">
+      Haskell.initFFI();
+    </script>
+  </head>
+  <body>
+    <script type="text/javascript" src="Test.js"></script>
+  </body>
+</html>

--- a/lib/javascript-ffi-threepenny/build-microhs.sh
+++ b/lib/javascript-ffi-threepenny/build-microhs.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+mhs -tweb -i./src Foreign.TestJavaScript -oTest.js

--- a/lib/javascript-ffi-threepenny/javascript-ffi-threepenny.cabal
+++ b/lib/javascript-ffi-threepenny/javascript-ffi-threepenny.cabal
@@ -2,17 +2,27 @@ name:                javascript-ffi-threepenny
 version:             0.1.0.0
 synopsis:            JavaScript FFI, used by threepenny-gui
 description:
-    Foreign Function Interface for JavaScript.
+    This package implements a Foreign Function Interface (FFI) for JavaScript.
     .
-    This JavaScript FFI implements a small web server.
-    When a web browser connects to this web server,
-    this library allows you to communicate with
-    the JavaScript environment in the browser.
+    This JavaScript FFI allows you to call JavaScript code from Haskell,
+    and (more limited) Haskell code from JavaScript.    
     .
-    NOTE: This library contains examples, but they are not built by default.
-    To build and install the example, use the @buildExamples@ flag like this
+    This JavaScript FFI is implemented in multiple ways:
     .
-    @cabal install threepenny-gui -fbuildExamples@
+    * When compiled to native code via GHC, this package implements a small web server.
+      Loading a page will open a WebSocket connection
+      between browser window and server.
+      Then, you can call JavaScript functions in the browser window
+      from the server code.
+    .
+    * When compiled to WebAssembly
+      via [MicroHs](https://github.com/augustss/MicroHs) and emscripten,
+      this package allows you to call JavaScript functions in the same runtime environment
+      — using the same API as the use case above.
+    .
+    This package is tailored to the needs of the
+    [threepenny-gui](https://heinrichapfelmus.github.io/threepenny-gui/)
+    package, but can be used independently.
 
 license:             BSD3
 author:              Heinrich Apfelmus
@@ -42,11 +52,6 @@ extra-source-Files:
     , js/*.css
     , js/*.js
     , js/lib/*.js
-
-flag buildExamples
-    description: Build example executables.
-    default:     False
-    manual:      True
 
 flag rebug
     description: The library uses some techniques that are highly

--- a/lib/javascript-ffi-threepenny/javascript-ffi-threepenny.cabal
+++ b/lib/javascript-ffi-threepenny/javascript-ffi-threepenny.cabal
@@ -73,6 +73,7 @@ library
     Foreign.RemotePtr
   other-modules:
     Foreign.JavaScript.CallBuffer
+    Foreign.JavaScript.CallJavaScript
     Foreign.JavaScript.EventLoop
     Foreign.JavaScript.Include
     Foreign.JavaScript.JSON

--- a/lib/javascript-ffi-threepenny/javascript-ffi-threepenny.cabal
+++ b/lib/javascript-ffi-threepenny/javascript-ffi-threepenny.cabal
@@ -73,6 +73,7 @@ library
     Foreign.RemotePtr
   other-modules:
     Foreign.JavaScript.CallBuffer
+    Foreign.JavaScript.CallHaskell
     Foreign.JavaScript.CallJavaScript
     Foreign.JavaScript.EventLoop
     Foreign.JavaScript.Include

--- a/lib/javascript-ffi-threepenny/js/ffi-microhs.js
+++ b/lib/javascript-ffi-threepenny/js/ffi-microhs.js
@@ -1,0 +1,79 @@
+/* *********************************************************************
+  Foreign Function Interface (FFI)
+  JavaScript <-> Haskell
+
+  This module implements everything necessary to call JS functions
+  from Haskell and vice versa.
+
+    * Listen to server and call JS functions on request.
+    * Present Haskell functions as objects that can be called from JS.
+    * StablePtr for JS objects.
+
+********************************************************************* */
+
+// Connect to the Haskell server and initialize the FFI.
+// An optional string argument can be used to specify the server URL.
+Haskell.initFFI = function () {
+
+  /////////////////////////////////////////////////////////////////////
+  // Calling Haskell functions
+
+  // An event is a function on the server side that can be called anytime,
+  // but whose execution will be queued.
+  Haskell.newEvent = function (name, args) {
+    var that = function () {
+      var theargs = [];
+      if (args) {
+        // 'args' is a string that contains the name 'arguments'
+        // Evaluating it will perform appropriate marshalling.
+        theargs = eval(args);
+      } else {
+        for (var i=0; i<arguments.length; i++) {
+          theargs[i] = arguments[i];
+        }
+      }
+
+      Module._callbackHs(
+        stringToNewUTF8(name),
+        stringToNewUTF8(JSON.stringify(theargs))
+      );
+    };
+    return that;
+  };
+
+  /////////////////////////////////////////////////////////////////////
+  // Stable Pointers on JavaScript objects
+  //
+  // Warning: We assume that each object can have at most one StablePtr
+  // associated to it. We have to pay attention that we don't
+  // free a stable pointer twice.
+  var stablePtrs = {};
+  var counter    = 0;
+
+  var newStablePtr = function (object) {
+    if (object.stablePtr === undefined) {
+      object.stablePtr = 'js-' + counter.toString();
+      stablePtrs[object.stablePtr] = object;
+      counter++;
+    }
+    return object.stablePtr.toString();
+  };
+
+  Haskell.imposeStablePtr = function (object, ptr) {
+    object.stablePtr = ptr;
+    stablePtrs[object.stablePtr] = object;
+  };
+
+  Haskell.getStablePtr = function (object) {
+    return (object.stablePtr || newStablePtr(object));
+  };
+
+  Haskell.deRefStablePtr = function (ptr) {
+    return stablePtrs[ptr];
+  };
+
+  Haskell.freeStablePtr = function (ptr) {
+    delete stablePtrs[ptr].stablePtr;
+    delete stablePtrs[ptr];
+  };
+};

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript.hs
@@ -35,6 +35,7 @@ module Foreign.JavaScript
     , debug, timestamp
     ) where
 
+import           Foreign.JavaScript.CallHaskell
 import           Foreign.JavaScript.CallBuffer
 import           Foreign.JavaScript.EventLoop
 import           Foreign.JavaScript.Marshal

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript.hs
@@ -1,19 +1,18 @@
-{-# LANGUAGE RecordWildCards #-}
+{- | A Foreign Function Interface (FFI) for JavaScript.
+
+This module allows you to call JavaScript from Haskell, and vice-versa.
+
+This module consists of two parts:
+
+* When compiled with GHC, a web server implementation.
+  This server communicates with a web browser window
+  and uses the JavaScript in that window to execute JavaScript code.
+* An interface for calling JavaScript functions from Haskell and vice-versa.
+  The main functions are 'ffi', 'runFunction', and 'callFunction'.
+-}
 module Foreign.JavaScript
     (
-    -- * Synopsis
-    -- | A JavaScript foreign function interface (FFI).
-    --
-    -- This module implements a web server that communicates with
-    -- a web browser and allows you to execute arbitrary JavaScript code on it.
-    --
-    -- NOTE: This module is used internally by the "Graphics.UI.Threepenny"
-    -- library, but the types are /not/ compatible directly
-    -- (although some escape hatches are provided).
-    -- Use "Foreign.JavaScript" only if you want to roll your own
-    -- interface to the web browser.
-
-    -- * Server
+    -- * Server    
     serve, defaultConfig, Config(
           jsPort, jsAddr
         , jsCustomHTML, jsStatic, jsLog
@@ -24,11 +23,15 @@ module Foreign.JavaScript
     , Window, getServer, getCookies, root
 
     -- * JavaScript FFI
+    -- ** Types
     , ToJS(..), FromJS, JSFunction, JSObject, JavaScriptException
+    -- ** Calling JavaScript from Haskell
     , FFI, ffi, runFunction, callFunction
     , NewJSObject, unsafeCreateJSObject
     , CallBufferMode(..), setCallBufferMode, getCallBufferMode, flushCallBuffer
+    -- ** Calling Haskell from JavaScript
     , IsHandler, exportHandler, onDisconnect
+    -- ** Debugging
     , debug, timestamp
     ) where
 

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallHaskell.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallHaskell.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Call Haskell from JavaScript.
+--
+-- In the web browser implementation, we do not support
+-- arbitrary nesting of JavaScript and Haskell code.
+-- Instead, Haskell code must be called as \"events\",
+-- which do not return results back to JavaScript code.
+module Foreign.JavaScript.CallHaskell
+    ( newHandler
+    ) where
+
+import Foreign.JavaScript.Types
+    ( HsEvent, Window(Window,wEventHandlers) )
+
+import qualified Data.Aeson         as JSON
+import qualified Foreign.RemotePtr  as RemotePtr
+
+{-----------------------------------------------------------------------------
+    Exports, Imports and garbage collection
+------------------------------------------------------------------------------}
+-- | Turn a Haskell function into an event handler.
+newHandler :: Window -> ([JSON.Value] -> IO ()) -> IO HsEvent
+newHandler Window{wEventHandlers} handler = do
+    coupon <- RemotePtr.newCoupon wEventHandlers
+    RemotePtr.newRemotePtr coupon (handler . parseArgs) wEventHandlers
+  where
+    fromSuccess (JSON.Success x) = x
+    -- parse a genuine JavaScript array
+    parseArgs x = fromSuccess (JSON.fromJSON x) :: [JSON.Value]
+    -- parse a JavaScript arguments object
+    -- parseArgs x = Map.elems (fromSuccess (JSON.fromJSON x) :: Map.Map String JSON.Value)

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallHaskell.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallHaskell.hs
@@ -13,8 +13,8 @@ module Foreign.JavaScript.CallHaskell
 import Foreign.JavaScript.Types
     ( HsEvent, Window(Window,wEventHandlers) )
 
-import qualified Data.Aeson         as JSON
-import qualified Foreign.RemotePtr  as RemotePtr
+import qualified Foreign.JavaScript.JSON  as JSON
+import qualified Foreign.RemotePtr        as RemotePtr
 
 {-----------------------------------------------------------------------------
     Exports, Imports and garbage collection

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallJavaScript.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallJavaScript.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Call JavaScript from Haskell.
+module Foreign.JavaScript.CallJavaScript
+    ( fromJSStablePtr, newJSObjectFromCoupon
+    ) where
+
+import Foreign.JavaScript.CallBuffer
+    ( bufferRunEval )
+import Foreign.JavaScript.Types
+    ( JSObject, JSPtr (..), Window(Window,wJSObjects) )
+
+import qualified Data.Aeson         as JSON
+import qualified Data.Text          as T
+import qualified Foreign.RemotePtr  as RemotePtr
+
+{-----------------------------------------------------------------------------
+    Create JSObject
+------------------------------------------------------------------------------}
+-- | Retrieve 'JSObject' associated with a JavaScript stable pointer.
+fromJSStablePtr :: JSON.Value -> Window -> IO JSObject
+fromJSStablePtr js w@(Window{wJSObjects}) = do
+    let JSON.Success coupon = JSON.fromJSON js
+    mhs <- RemotePtr.lookup coupon wJSObjects
+    case mhs of
+        Just hs -> return hs
+        Nothing -> newJSObjectFromCoupon w coupon
+
+-- | Create a new JSObject by registering a new coupon.
+newJSObjectFromCoupon :: Window -> RemotePtr.Coupon -> IO JSObject
+newJSObjectFromCoupon w@(Window{wJSObjects}) coupon = do
+    ptr <- RemotePtr.newRemotePtr coupon (JSPtr coupon) wJSObjects
+    RemotePtr.addFinalizer ptr $
+        bufferRunEval w ("Haskell.freeStablePtr('" ++ T.unpack coupon ++ "')")
+    return ptr

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallJavaScript.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallJavaScript.hs
@@ -10,9 +10,9 @@ import Foreign.JavaScript.CallBuffer
 import Foreign.JavaScript.Types
     ( JSObject, JSPtr (..), Window(Window,wJSObjects) )
 
-import qualified Data.Aeson         as JSON
-import qualified Data.Text          as T
-import qualified Foreign.RemotePtr  as RemotePtr
+import qualified Data.Text                  as T
+import qualified Foreign.JavaScript.JSON    as JSON
+import qualified Foreign.RemotePtr          as RemotePtr
 
 {-----------------------------------------------------------------------------
     Create JSObject

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/EventLoop.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/EventLoop.hs
@@ -3,7 +3,6 @@
 module Foreign.JavaScript.EventLoop
     ( eventLoop
     , runEval, callEval, debug, onDisconnect
-    , newHandler
     ) where
 
 import           Control.Concurrent
@@ -165,19 +164,3 @@ eventLoop initialize server info comm = void $ do
 flushCallBufferPeriodically :: Window -> IO ()
 flushCallBufferPeriodically w =
     forever $ threadDelay (flushPeriod*1000) >> flushCallBuffer w
-
-
-{-----------------------------------------------------------------------------
-    Exports, Imports and garbage collection
-------------------------------------------------------------------------------}
--- | Turn a Haskell function into an event handler.
-newHandler :: Window -> ([JSON.Value] -> IO ()) -> IO HsEvent
-newHandler Window{wEventHandlers} handler = do
-    coupon <- newCoupon wEventHandlers
-    newRemotePtr coupon (handler . parseArgs) wEventHandlers
-    where
-    fromSuccess (JSON.Success x) = x
-    -- parse a genuine JavaScript array
-    parseArgs x = fromSuccess (JSON.fromJSON x) :: [JSON.Value]
-    -- parse a JavaScript arguments object
-    -- parseArgs x = Map.elems (fromSuccess (JSON.fromJSON x) :: Map.Map String JSON.Value)

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/JSON.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/JSON.hs
@@ -4,7 +4,7 @@
 -- | 'JSON' utilities needed for marshaling to/from JavaScript.
 module Foreign.JavaScript.JSON
     ( -- * Type
-      Value
+      Value (..)
 
     -- * Construction
     , string
@@ -26,6 +26,7 @@ import qualified Data.Text as T
 data Value
     = Raw T.Text    -- Unparsed textual representation.
     | Array [Value] -- FIXME: Actually parse this.
+    | Null
 
 string :: T.Text -> Value
 string t = Raw ("\"" <> t <> "\"")

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/Marshal.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/Marshal.hs
@@ -15,7 +15,7 @@ module Foreign.JavaScript.Marshal
 import           Data.List                        (intercalate)
 import qualified Data.Text              as T
 
-import Foreign.JavaScript.EventLoop
+import Foreign.JavaScript.CallJavaScript
     ( fromJSStablePtr, newJSObjectFromCoupon )
 import Foreign.JavaScript.Types
     ( HsEvent, JSObject, NewJSObject(..), Window(Window,wJSObjects) )

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/MicroHs.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/MicroHs.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE RecordWildCards #-}
+module Foreign.JavaScript.MicroHs
+    ( withBrowserWindow
+    ) where
+
+import           Foreign.JavaScript.Types
+import qualified Foreign.JavaScript.JSON        as JSON
+import qualified Foreign.RemotePtr              as RemotePtr
+
+import Data.IORef
+    ( IORef, newIORef, readIORef, writeIORef )
+import Data.Text
+    ( grabCString, useAsCString, pack, unpack )
+import Foreign.C.String
+    ( CString )
+import System.IO.Unsafe
+    ( unsafePerformIO )
+
+foreign import javascript "console.log(UTF8ToString($0))"
+    ffiDebug :: CString -> IO ()
+foreign import javascript "eval(UTF8ToString($0))"
+    ffiRunEval :: CString -> IO ()
+foreign import javascript "return stringToNewUTF8(JSON.stringify(eval(UTF8ToString($0))))"
+    ffiCallEval :: CString -> IO CString
+
+foreign export javascript callbackHs
+    :: CString -> CString -> IO ()
+
+{-----------------------------------------------------------------------------
+    Server
+------------------------------------------------------------------------------}
+refWindow :: IORef Window
+refWindow = unsafePerformIO (newPartialWindow >>= newIORef)
+
+-- | Run when the browser 'Window' is initialized.
+withBrowserWindow :: (Window -> IO ()) -> IO ()
+withBrowserWindow action = do
+    w0 <- readIORef refWindow
+    let wdebug = \s -> useAsCString (pack s) ffiDebug
+    let w1 = w0
+            { debug    = \s -> useAsCString (pack s) ffiDebug
+            , runEval  = \s -> useAsCString (pack s) ffiRunEval
+            , callEval = \s -> do
+                t <- useAsCString (pack s) $
+                    \p -> ffiCallEval p >>= grabCString
+                pure $ JSON.Raw t
+            }
+    writeIORef refWindow w1
+    action w1
+
+-- Module._callbackHs(stringToNewUTF8('hello'))
+callbackHs :: CString -> CString -> IO ()
+callbackHs cname cargs = do
+    name <- grabCString cname
+    args <- grabCString cargs
+    w <- readIORef refWindow
+    handleEvent w (name, JSON.Raw args)
+
+-- | Handle a single event
+handleEvent :: Window -> (RemotePtr.Coupon, JSON.Value) -> IO ()
+handleEvent Window{debug,wEventHandlers} (name, args) = do
+    mhandler <- RemotePtr.lookup name wEventHandlers
+    case mhandler of
+        Nothing -> pure ()
+        Just f  -> do
+            RemotePtr.withRemotePtr f (\_ g -> g args)

--- a/lib/javascript-ffi-threepenny/src/Foreign/RemotePtr.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/RemotePtr.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE RecordWildCards#-}
+
+-- | Toolbox for managing remote objects in Haskell.
 module Foreign.RemotePtr (
-    -- * Synopsis
-    -- | Toolbox for managing remote objects in Haskell.
-    
     -- * RemotePtr
       RemotePtr
     , withRemotePtr, addFinalizer, destroy, addReachable, clearReachable
@@ -48,13 +47,15 @@ type Coupon = T.Text
 
 -- | A 'RemotePtr' is a pointer to a foreign object.
 -- 
--- Like a 'ForeignPtr', it refers to an object managed by an environment
+-- Like a 'Foreign.ForeignPtr.ForeignPtr',
+-- it refers to an object managed by an environment
 -- external to the Haskell runtime.
 -- Likewise, you can assign finalizers to a 'RemotePtr'. The finalizers
 -- will be run when the Haskell runtime garbage collects this value.
 -- They can perform some cleanup operations, like freeing memory.
 --
--- Unlike a 'ForeignPtr', the object referenced by a 'RemotePtr' is not
+-- Unlike a 'Foreign.ForeignPtr.ForeignPtr',
+-- the object referenced by a 'RemotePtr' is not
 -- necessarily a block of RAM. Instead, it can refer to things like an object
 -- managed by a remote program.
 

--- a/lib/javascript-ffi-threepenny/src/Foreign/RemotePtr/Weak.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/RemotePtr/Weak.hs
@@ -12,6 +12,31 @@ module Foreign.RemotePtr.Weak
     ) where
 
 import Prelude
+
+#if defined(__MHS__)
+{-----------------------------------------------------------------------------
+    MicroHs
+------------------------------------------------------------------------------}
+import Data.IORef hiding (mkWeakIORef)
+
+type Weak = IORef
+
+mkWeakIORef :: IORef a -> IO () -> IO (Weak (IORef a))
+mkWeakIORef ref _ = newIORef ref
+
+mkWeakIORefValue :: IORef a -> value -> IO () -> IO (Weak value)
+mkWeakIORefValue _ v _ = newIORef v
+
+deRefWeak :: Weak v -> IO (Maybe v)
+deRefWeak ref = Just <$> readIORef ref
+
+finalize :: Weak v -> IO ()
+finalize _ = pure ()
+
+#else
+{-----------------------------------------------------------------------------
+    GHC
+------------------------------------------------------------------------------}
 import Data.IORef
     ( IORef, mkWeakIORef )
 import System.Mem.Weak
@@ -22,9 +47,6 @@ import qualified GHC.Weak  as GHC
 import qualified GHC.IORef as GHC
 import qualified GHC.STRef as GHC
 
-{-----------------------------------------------------------------------------
-    Operations
-------------------------------------------------------------------------------}
 -- | Make 'Weak' pointer whose key is an 'IORef'.
 mkWeakIORefValue :: IORef a -> value -> IO () -> IO (Weak value)
 #if CABAL
@@ -38,4 +60,6 @@ mkWeakIORefValue (GHC.IORef (GHC.STRef r#)) v f = GHC.IO $ \s ->
 #else
 mkWeakIORefValue (GHC.IORef (GHC.STRef r#)) v (GHC.IO f) = GHC.IO $ \s ->
   case GHC.mkWeak# r# v f s of (# s1, w #) -> (# s1, GHC.Weak w #)
+#endif
+
 #endif

--- a/lib/javascript-ffi-threepenny/src/Foreign/TestJavaScript.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/TestJavaScript.hs
@@ -1,37 +1,29 @@
 {-----------------------------------------------------------------------------
-    threepenny-gui
-    
-    This module is for quick testing of the Foreign.JavaScript code.
+    Quick test of Foreign.JavaScript
 ------------------------------------------------------------------------------}
+module Foreign.TestJavaScript where
 
-import Data.Aeson as JSON
 import Data.IORef
 import Foreign.JavaScript
-import Foreign.RemotePtr
+    ( Window, JSObject, IsHandler
+    , withBrowserWindow, callFunction, runFunction, ffi, debug
+    , exportHandler
+    )
 
-main = test2
-
-{-----------------------------------------------------------------------------
-    Call a JS function and route result through server
-------------------------------------------------------------------------------}
-{-
-test1 = serve defaultConfig $ \w -> do
-    x <- callEval "document.lastModified" w
-    runEval ("document.write('" ++ toString x ++ "')") w
-
-toString :: JSON.Value -> String
-toString x = let Success y = JSON.fromJSON x in y
--}
+import qualified Foreign.RemotePtr as RemotePtr
 
 {-----------------------------------------------------------------------------
     Create an element and an on-click handler
 ------------------------------------------------------------------------------}
-test2 = withPreventGC $ \ref -> serve defaultConfig $ \w -> do
-    body   <- getBody w
-    writeIORef ref body
+main :: IO ()
+main = withPreventGC $ \ref -> withBrowserWindow $ \w -> do
+    pure ()
+    body <- getBody w
+    writeIORef ref $ Just body
 
     button <- newElement "button" w
     runFunction w $ ffi "$(%1).text('Click me!')" button
+
     let handler = do
             msg <- newElement "div" w
             let s = "I have been clicked."
@@ -44,17 +36,20 @@ test2 = withPreventGC $ \ref -> serve defaultConfig $ \w -> do
     addHandler "click" handler button w
 
     appendChild body button w
+    pure ()
 
 getBody :: Window -> IO Element
 getBody w = callFunction w $
     ffi "document.getElementsByTagName('body')[0]"
 
+withPreventGC :: (IORef (Maybe a) -> IO ()) -> IO ()
 withPreventGC f = do
-    ref <- newIORef $ error "It's fine, just keeping value alive."
+    ref <- newIORef Nothing
     f ref
-    x  <- readIORef ref
-    x `seq` return ()
-
+    mx  <- readIORef ref
+    case mx of
+        Nothing -> pure ()
+        Just x  -> x `seq` pure ()
 
 {-----------------------------------------------------------------------------
     DOM Manipulation
@@ -70,7 +65,7 @@ newElement tag w = callFunction w $
 addHandler :: IsHandler a => String -> a -> Element -> Window -> IO ()
 addHandler name handler e w = do
     handlerPtr <- exportHandler w handler
-    addReachable e handlerPtr                   -- make handler reachable from element
+    RemotePtr.addReachable e handlerPtr     -- make handler reachable from element
     runFunction w $ ffi "Haskell.on(%1,%2,%3)" e name handlerPtr
 
 -- | Append a child element to a parent element.
@@ -78,6 +73,5 @@ appendChild :: Element -> Element -> Window -> IO ()
 appendChild eParent eChild w = do
     -- FIXME: We have to stop the child being reachable from its
     -- /previous/ parent.
-    addReachable eParent eChild
+    RemotePtr.addReachable eParent eChild
     runFunction w $ ffi "$(%1).append($(%2))" eParent eChild
-


### PR DESCRIPTION
This pull request refactors the JavaScript FFI to be compatible with Lennart Augustsson's [MicroHs](https://github.com/augustss/MicroHs/tree/master) compiler.

This pull request makes the `Foreign.TestJavaScript` example work — after running `build.sh`, the `Test.html` page runs JavaScript code that does what we expect. This pull request does not try to be polished — we have taken a few shortcuts, to be cleaned up.