### PR TITLE
Remove dependency on `exceptions`

### DIFF
--- a/lib/threepenny-gui/CHANGELOG.md
+++ b/lib/threepenny-gui/CHANGELOG.md
@@ -2,16 +2,23 @@
 
 **0.10.0.0** – Snapshot release
 
+Added
+
+* Specialized functions for exceptions: `throwUI`, `catchUI`, `handleUI`.
+
 Changed
 
 * Split off JavaScript FFI to `javascript-ffi-threepenny`.
 * Remove dependency on `aeson` and use `JSON` type from JavaScript FFI instead.
-  * Change `EventData`, `unsafeFromJSON`.
+  * Change type `EventData`, function `unsafeFromJSON`.
 
 Removed
 
-* Dependency on `data-default` package.
+* Remove dependency on `data-default` package.
   * Remove instance `Default Easing`.
+* Remove dependency on `exceptions` package.
+  * Remove instances `MonadThrow UI` and `MonadCatch UI`.
+    Use newly added specialized functions such as `throwUI` instead.
 
 **0.9.4.2** – Maintenance and snapshot release
 

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Core.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Core.hs
@@ -10,7 +10,8 @@ module Graphics.UI.Threepenny.Core (
 
     -- * UI monad
     -- $ui
-    UI, runUI, MonadUI(..), askWindow, liftIOLater,
+    UI, runUI, MonadUI(..), throwUI, catchUI, handleUI,
+    askWindow, liftIOLater,
     module Control.Monad.IO.Class,
     module Control.Monad.Fix,
 
@@ -63,7 +64,6 @@ import Control.Monad          (forM_, forM, void)
 import Control.Monad.Fix
 import Control.Monad.IO.Class
 
-import qualified Control.Monad.Catch             as E
 import qualified Foreign.JavaScript              as JS
 import qualified Foreign.JavaScript.JSON         as JSON
 import qualified Graphics.UI.Threepenny.Internal as Core
@@ -176,7 +176,7 @@ getElementById
     -> String              -- ^ The ID string.
     -> UI (Maybe Element)  -- ^ Element (if any) with given ID.
 getElementById _ ident =
-    E.handle (\(_ :: JS.JavaScriptException) -> return Nothing) $
+    handleUI (\(_ :: JS.JavaScriptException) -> return Nothing) $
         fmap Just . fromJSObject
             =<< callFunction (ffi "document.getElementById(%1)" ident)
 

--- a/lib/threepenny-gui/threepenny-gui.cabal
+++ b/lib/threepenny-gui/threepenny-gui.cabal
@@ -99,8 +99,7 @@ library
 
   if impl(ghc)
     build-depends:
-        exceptions                 >=0.6   && <0.11
-      , hashable                   >=1.2.0 && <1.6
+        hashable                   >=1.2.0 && <1.6
       , stm                        >=2.2   && <2.6
       , text                       >=0.11  && <2.2
       , unordered-containers       >=0.2   && <0.3


### PR DESCRIPTION
This pull request removes the dependency on the `exceptions` package.

The goal is to reduce the dependency footprint until the package can be compiled with MicroHs.