### PR TITLE
Change container type and remove dependency on `hashable`

### DIFF
--- a/lib/threepenny-gui/src/Reactive/Threepenny/Types.hs
+++ b/lib/threepenny-gui/src/Reactive/Threepenny/Types.hs
@@ -3,7 +3,6 @@ module Reactive.Threepenny.Types where
 import Control.Monad.Trans.RWS.Lazy
 import Data.Functor.Identity ()
 
-import           Data.Hashable
 import qualified Data.Vault.Strict   as Vault.Strict
 import           Data.Unique.Really
 
@@ -16,13 +15,9 @@ type Handler  = EvalP (IO ())
 data Priority = DoLatch | DoIO deriving (Eq,Show,Ord,Enum)
 
 data Pulse a = Pulse
-    { addHandlerP :: ((Unique, Priority), Handler) -> Build (IO ())
+    { addHandlerP :: (Unique, Priority, Handler) -> Build (IO ())
     , evalP       :: EvalP (Maybe a)
     }
-
-instance Hashable Priority where
-    hashWithSalt = hashUsing fromEnum
-    hash         = fromEnum
 
 data Latch a = Latch { readL :: EvalL a }
 

--- a/lib/threepenny-gui/threepenny-gui.cabal
+++ b/lib/threepenny-gui/threepenny-gui.cabal
@@ -99,8 +99,7 @@ library
 
   if impl(ghc)
     build-depends:
-        hashable                   >=1.2.0 && <1.6
-      , stm                        >=2.2   && <2.6
+        stm                        >=2.2   && <2.6
       , text                       >=0.11  && <2.2
       , unordered-containers       >=0.2   && <0.3
       , vault                      >=0.3   && <0.4


### PR DESCRIPTION
This pull request changes the container type used in `Reactive.Threepenny.PulseLatch`, which in turn allows us to remove the dependency on the `hashable` package.