### PR TITLE
Tidy source code for `threepenny-gui`

### DIFF
--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallBuffer.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallBuffer.hs
@@ -68,11 +68,11 @@ bufferRunEval Window{wCallBufferMode,wCallBuffer,runEval} code = do
         mode <- readTVar wCallBufferMode
         case mode of
             NoBuffering -> do
-                return $ Just code
+                pure $ Just code
             _ -> do
                 msg <- takeTMVar wCallBuffer
                 putTMVar wCallBuffer (msg . (\s -> ";" ++ code ++ s))
-                return Nothing
+                pure Nothing
     case action of
         Nothing    -> pure ()
         Just code1 -> runEval code1

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallJavaScript.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallJavaScript.hs
@@ -23,7 +23,7 @@ fromJSStablePtr js w@(Window{wJSObjects}) = do
     let JSON.Success coupon = JSON.fromJSON js
     mhs <- RemotePtr.lookup coupon wJSObjects
     case mhs of
-        Just hs -> return hs
+        Just hs -> pure hs
         Nothing -> newJSObjectFromCoupon w coupon
 
 -- | Create a new JSObject by registering a new coupon.
@@ -32,4 +32,4 @@ newJSObjectFromCoupon w@(Window{wJSObjects}) coupon = do
     ptr <- RemotePtr.newRemotePtr coupon (JSPtr coupon) wJSObjects
     RemotePtr.addFinalizer ptr $
         bufferRunEval w ("Haskell.freeStablePtr('" ++ T.unpack coupon ++ "')")
-    return ptr
+    pure ptr

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/Marshal.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/Marshal.hs
@@ -39,7 +39,7 @@ class ToJS a where
         jsCode $ "[" ++ intercalate "," (map unJSCode ys) ++ "]"
 
 jsCode :: String -> IO JSCode
-jsCode = return . JSCode
+jsCode = pure . JSCode
 
 instance ToJS Float      where render   = render . JSON.toJSON
 instance ToJS Double     where render   = render . JSON.toJSON
@@ -78,7 +78,7 @@ simple :: JSON.FromJSON a => (JSCode -> JSCode) -> FromJS' a
 simple f =
     FromJS' { wrapCode = f , marshal = \_ -> fromSuccessIO . JSON.fromJSON }
     where
-    fromSuccessIO (JSON.Success a) = return a
+    fromSuccessIO (JSON.Success a) = pure a
 
 instance FromJS Double     where fromJS = simple id
 instance FromJS Float      where fromJS = simple id
@@ -88,7 +88,7 @@ instance FromJS T.Text     where fromJS = simple $ apply1 "%1.toString()"
 instance FromJS JSON.Value where fromJS = simple id
 
 instance FromJS ()         where
-    fromJS = FromJS' { wrapCode = id, marshal = \_ _ -> return () }
+    fromJS = FromJS' { wrapCode = id, marshal = \_ _ -> pure () }
 
 instance FromJS JSObject   where
     fromJS = FromJS'
@@ -105,7 +105,7 @@ instance FromJS [JSObject] where
         }
 
 instance FromJS NewJSObject where
-    fromJS = FromJS' { wrapCode = id, marshal = \_ _ -> return NewJSObject }
+    fromJS = FromJS' { wrapCode = id, marshal = \_ _ -> pure NewJSObject }
 
 -- | Impose a JS stable pointer upon a newly created JavaScript object.
 --   In this way, JSObject can be created without waiting for the browser
@@ -115,8 +115,8 @@ wrapImposeStablePtr (Window{wJSObjects}) f = do
     coupon  <- RemotePtr.newCoupon wJSObjects
     rcoupon <- render coupon
     rcode   <- code f
-    return $ JSFunction
-        { code = return $ apply "Haskell.imposeStablePtr(%1,%2)" [rcode, rcoupon]
+    pure $ JSFunction
+        { code = pure $ apply "Haskell.imposeStablePtr(%1,%2)" [rcode, rcoupon]
         , marshalResult = \w _ -> newJSObjectFromCoupon w coupon
         }
 
@@ -174,7 +174,7 @@ instance FromJS b        => FFI (JSFunction b) where
 -- The class instances for the 'FFI' class show which conversions are supported.
 --
 ffi :: FFI a => String -> a
-ffi macro = fancy (return . apply macro)
+ffi macro = fancy (pure . apply macro)
 
 testFFI :: String -> Int -> JSFunction String
 testFFI = ffi "$(%1).prop('checked',%2)"

--- a/lib/threepenny-gui/samples/BarTab.hs
+++ b/lib/threepenny-gui/samples/BarTab.hs
@@ -16,7 +16,7 @@ main = startGUI defaultConfig setup
 setup :: Window -> UI ()
 setup w = do
     -- active elements
-    return w # set title "BarTab"
+    pure w # set title "BarTab"
 
     elAdd    <- UI.button # set UI.text "Add"
     elRemove <- UI.button # set UI.text "Remove"

--- a/lib/threepenny-gui/samples/Buttons.hs
+++ b/lib/threepenny-gui/samples/Buttons.hs
@@ -17,7 +17,7 @@ main = do
 
 setup :: Window -> UI ()
 setup w = void $ do
-    return w # set title "Buttons"
+    pure w # set title "Buttons"
     UI.addStyleSheet w "buttons.css"
 
     buttons <- mkButtons
@@ -35,7 +35,7 @@ mkButton :: String -> UI (Element, Element)
 mkButton title = do
     button <- UI.button #. "button" #+ [string title]
     view   <- UI.p #+ [element button]
-    return (button, view)
+    pure (button, view)
 
 mkButtons :: UI [Element]
 mkButtons = do
@@ -62,7 +62,7 @@ mkButtons = do
         element button2 # set text (button2Title ++ " [pressed]")
         element list    #+ [UI.li # set html "Zap! Quick result!"]
     
-    return [list, view1, view2]
+    pure [list, view1, view2]
 
   where button1Title = "Click me, I delay a bit"
         button2Title = "Click me, I work immediately"

--- a/lib/threepenny-gui/samples/CRUD.hs
+++ b/lib/threepenny-gui/samples/CRUD.hs
@@ -25,7 +25,7 @@ main = startGUI defaultConfig setup
 
 setup :: Window -> UI ()
 setup window = void $ mdo
-    return window # set title "CRUD Example (Simple)"
+    pure window # set title "CRUD Example (Simple)"
 
     -- GUI elements
     createBtn   <- UI.button #+ [string "Create"]
@@ -130,6 +130,6 @@ dataItem bItem = do
     entry1 <- UI.entry $ fst . maybe ("","") id <$> bItem
     entry2 <- UI.entry $ snd . maybe ("","") id <$> bItem
     
-    return ( (getElement entry1, getElement entry2)
+    pure ( (getElement entry1, getElement entry2)
            , (,) <$> UI.userText entry1 <*> UI.userText entry2
            )

--- a/lib/threepenny-gui/samples/Canvas.hs
+++ b/lib/threepenny-gui/samples/Canvas.hs
@@ -18,7 +18,7 @@ canvasSize = 400
 
 setup :: Window -> UI ()
 setup window = do
-    return window # set title "Canvas - Examples"
+    pure window # set title "Canvas - Examples"
 
     canvas <- UI.canvas
         # set UI.height canvasSize
@@ -74,7 +74,7 @@ setup window = do
         foldM (\start (delta, col) -> do
             let end = start+delta
             drawSlice (radian start) (radian end) col
-            return end) 0 pieData
+            pure end) 0 pieData
         UI.timestamp
 
 
@@ -91,7 +91,7 @@ setup window = do
 
     -- draw some text
     on UI.click drawText $ const $ do
-        return canvas
+        pure canvas
             # set UI.textFont    "30px sans-serif"
             # set UI.strokeStyle "gray"
             # set UI.fillStyle   (UI.htmlColor "black")

--- a/lib/threepenny-gui/samples/Chat.hs
+++ b/lib/threepenny-gui/samples/Chat.hs
@@ -31,7 +31,7 @@ setup :: Chan Message -> Window -> UI ()
 setup globalMsgs window = do
     msgs <- liftIO $ Chan.dupChan globalMsgs
 
-    return window # set title "Chat"
+    pure window # set title "Chat"
     
     (nickRef, nickname) <- mkNickname
     messageArea         <- mkMessageArea msgs nickRef
@@ -87,7 +87,7 @@ mkNickname = do
     
     nick <- liftIO $ newIORef ""
     on UI.keyup input $ \_ -> liftIO . writeIORef nick . trim =<< get value input
-    return (nick,el)
+    pure (nick,el)
 
 mkMessage :: Message -> UI Element
 mkMessage (timestamp, nick, content) =

--- a/lib/threepenny-gui/samples/CurrencyConverter.hs
+++ b/lib/threepenny-gui/samples/CurrencyConverter.hs
@@ -13,7 +13,7 @@ main = startGUI defaultConfig setup
 
 setup :: Window -> UI ()
 setup window = void $ do
-    return window # set title "Currency Converter"
+    pure window # set title "Currency Converter"
 
     dollar <- UI.input
     euro   <- UI.input

--- a/lib/threepenny-gui/samples/DragNDropExample.hs
+++ b/lib/threepenny-gui/samples/DragNDropExample.hs
@@ -16,7 +16,7 @@ main = do
 
 setup :: Window -> UI ()
 setup w = void $ do
-    return w # set title "Drag 'N' Drop Example"
+    pure w # set title "Drag 'N' Drop Example"
     UI.addStyleSheet w "DragNDropExample.css"
     
     pairs <- sequence $
@@ -57,5 +57,5 @@ mkDragPair color position = do
             # set text "Dropped!"
             # set UI.droppable False
     
-    return (elDrag, elDrop)
+    pure (elDrag, elDrop)
 

--- a/lib/threepenny-gui/samples/DrumMachine.hs
+++ b/lib/threepenny-gui/samples/DrumMachine.hs
@@ -20,7 +20,7 @@ bpm2ms bpm = ceiling $ 1000*60 / (fromIntegral bpm :: Double)
 
 instruments = words "kick snare hihat"
 
-loadInstrumentSample name = return $ "static/" ++ name ++ ".wav"
+loadInstrumentSample name = pure $ "static/" ++ name ++ ".wav"
 
 {-----------------------------------------------------------------------------
     Main
@@ -32,7 +32,7 @@ main = do
 
 setup :: Window -> UI ()
 setup w = void $ do
-    return w # set title "Ha-ha-ha-ks-ks-ks-ha-ha-ha-ell-ell-ell"
+    pure w # set title "Ha-ha-ha-ks-ks-ks-ha-ha-ha-ell-ell-ell"
 
     elBpm  <- UI.input # set value (show defaultBpm)
     elTick <- UI.span
@@ -53,7 +53,7 @@ setup w = void $ do
     -- allow user to set BPM
     on UI.keydown elBpm $ \keycode -> when (keycode == 13) $ void $ do
         bpm <- read <$> get value elBpm
-        return timer # set UI.interval (bpm2ms bpm)
+        pure timer # set UI.interval (bpm2ms bpm)
 
     -- start the timer
     UI.start timer
@@ -88,5 +88,5 @@ mkInstrument name = do
     elInstrument <- UI.div #. "instrument"
         #+ (element elAudio : UI.string name : elGroups)
 
-    return (beats, elInstrument)
+    pure (beats, elInstrument)
 

--- a/lib/threepenny-gui/samples/FadeInFadeOut.hs
+++ b/lib/threepenny-gui/samples/FadeInFadeOut.hs
@@ -11,7 +11,7 @@ main = startGUI defaultConfig setup
 
 setup :: Window -> UI ()
 setup w = do
-    return w # set title "fadeIn - fadeOut"
+    pure w # set title "fadeIn - fadeOut"
 
     button <- UI.button # set text "Click me to make me fade out and in!"
     getBody w #+ [column [UI.string "Demonstration of jQuery's animate() function"
@@ -19,4 +19,4 @@ setup w = do
     
     on UI.click button $ \_ -> do
         fadeOut button 400 Swing $ do
-            runUI w $ fadeIn button 400 Swing $ return ()
+            runUI w $ fadeIn button 400 Swing $ pure ()

--- a/lib/threepenny-gui/samples/GetElementsBy.hs
+++ b/lib/threepenny-gui/samples/GetElementsBy.hs
@@ -10,7 +10,7 @@ main = startGUI defaultConfig setup
 
 setup :: Window -> UI ()
 setup w = do
-    return w # set title "Element Test"
+    pure w # set title "Element Test"
 
     button1 <- UI.button # set UI.text "by tag"
     button2 <- UI.button # set UI.text "by class"

--- a/lib/threepenny-gui/samples/Mouse.hs
+++ b/lib/threepenny-gui/samples/Mouse.hs
@@ -11,7 +11,7 @@ main = startGUI defaultConfig setup
 
 setup :: Window -> UI ()
 setup w = do
-    return w # set title "Mouse"
+    pure w # set title "Mouse"
     
     out  <- UI.span # set text "Coordinates: "
     wrap <- UI.div #. "wrap"

--- a/lib/threepenny-gui/samples/Paths.hs
+++ b/lib/threepenny-gui/samples/Paths.hs
@@ -15,7 +15,7 @@ getStaticDir = (</> "samples/static") `liftM` Paths_threepenny_gui.getDataDir
 -- using GHCi
 
 getStaticDir :: IO FilePath
-getStaticDir = return "static"
+getStaticDir = pure "static"
 
 #endif
 

--- a/lib/threepenny-gui/samples/Svg.hs
+++ b/lib/threepenny-gui/samples/Svg.hs
@@ -12,7 +12,7 @@ main = startGUI defaultConfig setup
 
 setup :: Window -> UI ()
 setup w = void $ do
-    return w # set title "SVG"
+    pure w # set title "SVG"
 
     heading <- UI.h1 # set text "SVG Two Ways"
 
@@ -34,7 +34,7 @@ svgElems = do
         # set SVG.stroke "green"
         # set SVG.stroke_width "4"
         # set SVG.fill "yellow"
-    return context #+ [element elemCircle]
+    pure context #+ [element elemCircle]
 
 
 strCircle :: String

--- a/lib/threepenny-gui/samples/TestExceptions.hs
+++ b/lib/threepenny-gui/samples/TestExceptions.hs
@@ -13,10 +13,10 @@ main = startGUI defaultConfig { jsWindowReloadOnDisconnect = False } $ \w -> do
     case err of
             -- FIXME: This function should produce a useful error message
         1 -> runFunction $ ffi "alert(%1)" (error ("ouch " ++ show err) :: String)
-        2 -> UI.div # set UI.text (error ("ouch " ++ show err) :: String) >> return ()
+        2 -> UI.div # set UI.text (error ("ouch " ++ show err) :: String) >> pure ()
         3 -> error $ "ouch " ++ show err
         4 -> liftIO . ioError . userError $ "ouch " ++ show err
         5 -> runFunction $ ffi "throw('ouch')"
 
     getBody w #+ [UI.h1 # set UI.text "after error"]
-    return ()
+    pure ()

--- a/lib/threepenny-gui/samples/TestSpeed.hs
+++ b/lib/threepenny-gui/samples/TestSpeed.hs
@@ -14,7 +14,7 @@ main = startGUI defaultConfig setup
 
 setup :: Window -> UI ()
 setup window = void $ do
-    return window # set title "Test Speed"
+    pure window # set title "Test Speed"
 
     let msg = "This program tries to measure the speed at which HTML elements can be built."
     getBody window #+ [UI.string msg, UI.br]

--- a/lib/threepenny-gui/samples/TestURLFragments.hs
+++ b/lib/threepenny-gui/samples/TestURLFragments.hs
@@ -7,4 +7,4 @@ main = startGUI defaultConfig $ \w -> do
         [ UI.button # set UI.id_ "me" # set UI.text "Hello"
         , UI.a # set UI.href "#me" # set UI.text "Click me"
         ]
-    return ()
+    pure ()

--- a/lib/threepenny-gui/samples/WorkaroundFastEvent.hs
+++ b/lib/threepenny-gui/samples/WorkaroundFastEvent.hs
@@ -16,7 +16,7 @@ main = do
 
 setup :: Window -> UI ()
 setup window = do
-    return window # set title "Workaround for slow registering of event handlers"
+    pure window # set title "Workaround for slow registering of event handlers"
 
     button <- UI.button
         # set UI.text "Click me"
@@ -35,5 +35,5 @@ onElementId
     -> UI ()
 onElementId elid event handler = do
     window   <- askWindow
-    exported <- ffiExport (runUI window handler >> return ())
+    exported <- ffiExport (runUI window handler >> pure ())
     runFunction $ ffi "$(%1).on(%2,%3)" ("#"++elid) event exported

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny.hs
@@ -73,7 +73,7 @@ It builds the initial HTML page.
 
 First, set the title of the HTML document
 
->     return window # set UI.title "Hello World!"
+>     pure window # set UI.title "Hello World!"
 
 Then create a button element
 

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Elements.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Elements.hs
@@ -22,7 +22,7 @@ module Graphics.UI.Threepenny.Elements (
     underline, variable, video,
     ) where
 
-import           Control.Monad
+import           Control.Monad (void)
 import           Graphics.UI.Threepenny.Core
 import           Prelude                     hiding (div, map, span)
 

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Internal.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Internal.hs
@@ -115,7 +115,7 @@ instance ToJS Element where
     render = render . toJSObject
 
 getWindow :: Element -> IO Window
-getWindow = return . elWindow
+getWindow = pure . elWindow
 
 -- | Lookup or create reachability information for the children of
 -- an element that is represented by a JavaScript object.
@@ -128,10 +128,10 @@ getChildren el Window{ wChildren = wChildren } =
                 -- Create new pointer for reachability information.
                 ptr <- Foreign.newRemotePtr coupon () wChildren
                 Foreign.addReachable el ptr
-                return ptr
+                pure ptr
             Just p  ->
                 -- Return existing information
-                return p
+                pure p
 
 -- | Convert JavaScript object into an Element by attaching relevant information.
 -- The JavaScript object may still be subject to garbage collection.
@@ -139,7 +139,7 @@ fromJSObject0 :: JS.JSObject -> Window -> IO Element
 fromJSObject0 el window = do
     events   <- getEvents   el window
     children <- getChildren el window
-    return $ Element el events children window
+    pure $ Element el events children window
 
 -- | Convert JavaScript object into an element.
 --
@@ -170,7 +170,7 @@ addEvents el Window{ jsWindow = w, wEvents = wEvents } = do
         ptr <- Foreign.newRemotePtr coupon events wEvents
         Foreign.addReachable el ptr
 
-    return events
+    pure events
 
 -- | Lookup or create lazy events for a JavaScript object.
 getEvents :: JS.JSObject -> Window -> IO Events
@@ -179,7 +179,7 @@ getEvents el window@Window{ wEvents = wEvents } = do
         mptr <- Foreign.lookup coupon wEvents
         case mptr of
             Nothing -> addEvents el window
-            Just p  -> Foreign.withRemotePtr p $ \_ -> return
+            Just p  -> Foreign.withRemotePtr p $ \_ -> pure
 
 -- | Events may carry data. At the moment, they may return
 -- a single JSON value, as defined in the "Foreign.JavaScript.JSON" module.
@@ -293,7 +293,6 @@ instance Applicative UI where
     (<*>) = ap
 
 instance Monad UI where
-    return  = pure
     m >>= k = UI $ unUI m >>= unUI . k
 
 instance MonadIO UI where
@@ -328,7 +327,7 @@ runUI :: Window -> UI a -> IO a
 runUI window m = do
     (a, _, actions) <- Monad.runRWST (unUI m) window ()
     sequence_ actions
-    return a
+    pure a
 
 -- | Retrieve current 'Window' context in the 'UI' monad.
 askWindow :: UI Window
@@ -385,7 +384,7 @@ ffiExport :: JS.IsHandler a => a -> UI JSObject
 ffiExport fun = liftJSWindow $ \w -> do
     handlerPtr <- JS.exportHandler w fun
     Foreign.addReachable (JS.root w) handlerPtr
-    return handlerPtr
+    pure handlerPtr
 
 -- | Print a message on the client console if the client has debugging enabled.
 debug :: String -> UI ()

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Internal.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Internal.hs
@@ -24,7 +24,7 @@ module Graphics.UI.Threepenny.Internal (
     ) where
 
 import           Control.Exception (Exception, catch, throwIO)
-import           Control.Monad
+import           Control.Monad (ap, void)
 import           Control.Monad.Fix
 import           Control.Monad.IO.Class
 import qualified Control.Monad.Trans.RWS.Lazy as Monad

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/SVG/Attributes.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/SVG/Attributes.hs
@@ -80,11 +80,9 @@ module Graphics.UI.Threepenny.SVG.Attributes (
     unicode_bidi, visibility, word_spacing, writing_mode
     ) where
 
-
-import           Graphics.UI.Threepenny.Core (Element, WriteAttr, attr,
-                                              mkWriteAttr, set')
-import           Prelude                     hiding (exponent, filter, id, max,
-                                              min)
+import Prelude hiding (exponent, filter, id, max, min)
+import Graphics.UI.Threepenny.Core
+    ( Element, WriteAttr, attr, mkWriteAttr, set' )
 
 strAttr :: String -> WriteAttr Element String
 strAttr n = mkWriteAttr (set' (attr n))

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Timer.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Timer.hs
@@ -45,7 +45,7 @@ timer = liftIO $ do
     let tRunning  = fromTVar tvRunning
         tInterval = fromTVar tvInterval 
     
-    return $ Timer {..}
+    pure $ Timer {..}
 
 -- | Timer event.
 tick :: Timer -> Event ()
@@ -84,7 +84,7 @@ fromGetSet f = mkReadWriteAttr (liftIO . fst . f) (\i x -> liftIO $ snd (f x) i)
 testTimer = do
     t <- timer
     void $ register (tick t) $ const $ putStr "Hello"
-    return t
+    pure t
         # set interval 1000
         # set running True
 -}

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Widgets.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Widgets.hs
@@ -59,7 +59,7 @@ entry bValue = do -- single text entry
 
     let _elementTE = input
         _userTE    = tidings bValue $ UI.valueChange input 
-    return TextEntry {..}
+    pure TextEntry {..}
 
 {-----------------------------------------------------------------------------
     List box
@@ -110,11 +110,11 @@ listBox bitems bsel bdisplay = do
             lookupIndex <$> bindices2 <@> UI.selectionChange list
         _elementLB   = list
 
-    return ListBox {..}
+    pure ListBox {..}
 
 items :: WriteAttr Element [UI Element]
 items = mkWriteAttr $ \i x -> void $ do
-    return x # set children [] #+ map (\j -> UI.option #+ [j]) i
+    pure x # set children [] #+ map (\j -> UI.option #+ [j]) i
 
 
 

--- a/lib/threepenny-gui/src/Reactive/Threepenny.hs
+++ b/lib/threepenny-gui/src/Reactive/Threepenny.hs
@@ -13,7 +13,6 @@ module Reactive.Threepenny (
 
     -- * Core Combinators
     -- | Minimal set of combinators for programming with 'Event' and 'Behavior'.
-    module Control.Applicative,
     never, filterJust, unionWith,
     accumE, apply, stepper,
     -- $classes
@@ -46,10 +45,9 @@ module Reactive.Threepenny (
     test, test_recursion1
     ) where
 
-import Control.Applicative
 import Control.Monad (void)
 import Control.Monad.Fix (mfix)
-import Control.Monad.IO.Class
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.IORef
 import qualified Data.Map as Map
 
@@ -243,6 +241,10 @@ accumE a e = liftIO $ do
 instance Functor Behavior where
     fmap f ~(B l e) = B (Prim.mapL f l) e
 
+-- | Think of it as
+--
+-- > pure x   = \time -> x
+-- > bf <*> bg = \time -> bf time (bg time)
 instance Applicative Behavior where
     pure a  = B (Prim.pureL a) never
     ~(B lf ef) <*> ~(B lx ex) =

--- a/lib/threepenny-gui/src/Reactive/Threepenny.hs
+++ b/lib/threepenny-gui/src/Reactive/Threepenny.hs
@@ -93,7 +93,7 @@ type Handler a = a -> IO ()
 newEvent :: IO (Event a, Handler a)
 newEvent = do
     (p, fire) <- Prim.newPulse
-    return (E $ fromPure p, fire)
+    pure (E $ fromPure p, fire)
 
 
 -- | Create a series of events with delayed initialization.
@@ -106,15 +106,15 @@ newEventsNamed :: Ord name
     -> IO (name -> Event a)                 -- ^ Series of events.
 newEventsNamed initialize = do
     eventsRef <- newIORef Map.empty
-    return $ \name -> E $ memoize $ do
+    pure $ \name -> E $ memoize $ do
         events <- readIORef eventsRef
         case Map.lookup name events of
-            Just p  -> return p
+            Just p  -> pure p
             Nothing -> do
                 (p, fire) <- Prim.newPulse
                 writeIORef eventsRef $ Map.insert name p events
                 initialize (name, E $ fromPure p, fire)
-                return p
+                pure p
 
 
 -- | Register an event 'Handler' for an 'Event'.
@@ -210,13 +210,13 @@ accumB :: MonadIO m => a -> Event (a -> a) -> m (Behavior a)
 accumB a e = liftIO $ do
     (l1,p1) <- Prim.accumL a =<< at (unE e)
     p2      <- Prim.mapP (const ()) p1
-    return $ B l1 (E $ fromPure p2)
+    pure $ B l1 (E $ fromPure p2)
 
 
 -- | Construct a time-varying function from an initial value and
 -- a stream of new values. Think of it as
 --
--- > stepper x0 ex = return $ \time ->
+-- > stepper x0 ex = pure $ \time ->
 -- >     last (x0 : [x | (timex,x) <- ex, timex < time])
 --
 -- Note that the smaller-than-sign in the comparison @timex < time@ means
@@ -229,14 +229,14 @@ stepper a e = accumB a (const <$> e)
 -- Example:
 --
 -- > accumE "x" [(time1,(++"y")),(time2,(++"z"))]
--- >    = return [(time1,"xy"),(time2,"xyz")]
+-- >    = pure [(time1,"xy"),(time2,"xyz")]
 --
 -- Note that the output events are simultaneous with the input events,
 -- there is no \"delay\" like in the case of 'accumB'.
 accumE :: MonadIO m =>  a -> Event (a -> a) -> m (Event a)
 accumE a e = liftIO $ do
     p <- fmap snd . Prim.accumL a =<< at (unE e)
-    return $ E $ fromPure p
+    pure $ E $ fromPure p
 
 instance Functor Behavior where
     fmap f ~(B l e) = B (Prim.mapL f l) e
@@ -340,7 +340,7 @@ mapAccum :: MonadIO m => acc -> Event (acc -> (x,acc)) -> m (Event x, Behavior a
 mapAccum acc ef = do
     e <- accumE (undefined,acc) ((. snd) <$> ef)
     b <- stepper acc (snd <$> e)
-    return (fst <$> e, b)
+    pure (fst <$> e, b)
 
 
 {-----------------------------------------------------------------------------
@@ -385,7 +385,7 @@ test = do
     e2 <- accumE 0 $ (+) <$> e1
     _  <- register e2 print
 
-    return fire
+    pure fire
 
 test_recursion1 :: IO (IO ())
 test_recursion1 = do
@@ -397,4 +397,4 @@ test_recursion1 = do
         pure (b, e2)
     _  <- register e2 print
 
-    return $ fire ()
+    pure $ fire ()

--- a/lib/threepenny-gui/src/Reactive/Threepenny/Memo.hs
+++ b/lib/threepenny-gui/src/Reactive/Threepenny/Memo.hs
@@ -4,7 +4,7 @@ module Reactive.Threepenny.Memo (
 
 import Control.Monad.Fix (mfix)
 import Data.IORef
-import System.IO.Unsafe
+import System.IO.Unsafe (unsafePerformIO)
 
 {-----------------------------------------------------------------------------
     Memoize time-varying values / computations

--- a/lib/threepenny-gui/src/Reactive/Threepenny/Memo.hs
+++ b/lib/threepenny-gui/src/Reactive/Threepenny/Memo.hs
@@ -19,15 +19,15 @@ fromPure :: a -> Memo a
 fromPure = Const
 
 at :: Memo a -> IO a
-at (Const a)    = return a
+at (Const a)    = pure a
 at (Memoized r) = do
     memo <- readIORef r
     case memo of
-        Right a -> return a
+        Right a -> pure a
         Left ma -> mfix $ \a' -> do
             writeIORef r $ Right a'
             a <- ma    -- allow some recursion
-            return a
+            pure a
 
 memoize :: IO a -> Memo a
 memoize m = unsafePerformIO $ Memoized <$> newIORef (Left m)

--- a/lib/threepenny-gui/src/Reactive/Threepenny/Monads.hs
+++ b/lib/threepenny-gui/src/Reactive/Threepenny/Monads.hs
@@ -9,4 +9,4 @@ import Reactive.Threepenny.Types
 runEvalP :: Values -> EvalP a -> IO (a, Values)
 runEvalP pulses m = do
     (a, s, _) <- runRWST m () pulses
-    return (a, s)
+    pure (a, s)

--- a/lib/threepenny-gui/src/Reactive/Threepenny/PulseLatch.hs
+++ b/lib/threepenny-gui/src/Reactive/Threepenny/PulseLatch.hs
@@ -14,7 +14,7 @@ module Reactive.Threepenny.PulseLatch (
     ) where
 
 
-import Control.Monad
+import Control.Monad (join, void)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.RWS     as Monad
 

--- a/lib/threepenny-gui/src/Reactive/Threepenny/PulseLatch.hs
+++ b/lib/threepenny-gui/src/Reactive/Threepenny/PulseLatch.hs
@@ -39,16 +39,16 @@ modifyIORef' ref f = atomicModifyIORef ref (\a -> (f a, ()))
 cacheEval :: EvalP (Maybe a) -> Build (Pulse a)
 cacheEval e = do
     key <- Vault.newKey
-    return $ Pulse
-        { addHandlerP = \_ -> return (return ())
+    pure $ Pulse
+        { addHandlerP = \_ -> pure (pure ())
         , evalP       = do
             vault <- Monad.get
             case Vault.lookup key vault of
-                Just a  -> return a
+                Just a  -> pure a
                 Nothing -> do
                     a <- e
                     Monad.put $ Vault.insert key a vault
-                    return a
+                    pure a
         }
 
 -- Add a dependency to a pulse, for the sake of keeping track of dependencies.
@@ -59,9 +59,9 @@ dependOn p q = p { addHandlerP = \h -> (>>) <$> addHandlerP p h <*> addHandlerP 
 whenPulse :: Pulse a -> (a -> IO ()) -> Handler
 whenPulse p f = do
     ma <- evalP p
-    case ma of
-        Just a  -> return (f a)
-        Nothing -> return $ return ()
+    pure $ case ma of
+        Just a  -> f a
+        Nothing -> pure ()
 
 {-----------------------------------------------------------------------------
     Interface to the outside world.
@@ -77,7 +77,7 @@ newPulse = do
         addHandlerP :: (Unique, Priority, Handler) -> Build (IO ())
         addHandlerP (uid,p,m) = do
             modifyIORef' handlersRef (Map.insert uid (p, m))
-            return $ modifyIORef' handlersRef (Map.delete uid)
+            pure $ modifyIORef' handlersRef (Map.delete uid)
 
         -- evaluate all handlers attached to this input pulse
         fireP a = do
@@ -90,7 +90,7 @@ newPulse = do
 
         evalP = join . Vault.lookup key <$> Monad.get
 
-    return (Pulse {..}, fireP)
+    pure (Pulse {..}, fireP)
 
 -- | Register a handler to be executed whenever a pulse occurs.
 addHandler :: Pulse a -> (a -> IO ()) -> Build (IO ())
@@ -109,25 +109,25 @@ readLatch = readL
 -- | Create a new pulse that never occurs.
 neverP :: Pulse a
 neverP = Pulse
-    { addHandlerP = const $ return (return ())
-    , evalP       = return Nothing
+    { addHandlerP = const $ pure (pure ())
+    , evalP       = pure Nothing
     }
 
 -- | Map a function over pulses.
 mapP :: (a -> b) -> Pulse a -> Build (Pulse b)
-mapP f p = (`dependOn` p) <$> cacheEval (return . fmap f =<< evalP p)
+mapP f p = (`dependOn` p) <$> cacheEval (pure . fmap f =<< evalP p)
 
 -- | Map an IO function over pulses. Is only executed once.
 unsafeMapIOP :: (a -> IO b) -> Pulse a -> Build (Pulse b)
 unsafeMapIOP f p = (`dependOn` p) <$> cacheEval (traverse' . fmap f =<< evalP p)
     where
     traverse' :: Maybe (IO a) -> EvalP (Maybe a)
-    traverse' Nothing  = return Nothing
+    traverse' Nothing  = pure Nothing
     traverse' (Just m) = Just <$> lift m
 
 -- | Filter occurrences. Only keep those of the form 'Just'.
 filterJustP :: Pulse (Maybe a) -> Build (Pulse a)
-filterJustP p = (`dependOn` p) <$> cacheEval (return . join =<< evalP p)
+filterJustP p = (`dependOn` p) <$> cacheEval (pure . join =<< evalP p)
 
 -- | Pulse that occurs when either of the pulses occur.
 -- Combines values with the indicated function when both occur.
@@ -137,7 +137,7 @@ unionWithP f p q = (`dependOn` q) . (`dependOn` p) <$> cacheEval eval
     eval = do
         x <- evalP p
         y <- evalP q
-        return $ case (x,y) of
+        pure $ case (x,y) of
             (Nothing, Nothing) -> Nothing
             (Just a , Nothing) -> Just a
             (Nothing, Just a ) -> Just a
@@ -150,7 +150,7 @@ applyP l p = (`dependOn` p) <$> cacheEval eval
     eval = do
         f <- lift $ readL l
         a <- evalP p
-        return $ f <$> a
+        pure $ f <$> a
 
 -- | Accumulate values in a latch.
 accumL :: a -> Pulse (a -> a) -> Build (Latch a, Pulse a)
@@ -168,11 +168,11 @@ accumL a p1 = do
     let handler = whenPulse p2 $ (writeIORef latch $!)
     void $ addHandlerP p2 (uid, DoLatch, handler)
     
-    return (l1,p2)
+    pure (l1,p2)
 
 -- | Latch whose value stays constant.
 pureL :: a -> Latch a
-pureL a = Latch { readL = return a }
+pureL a = Latch { readL = pure a }
 
 -- | Map a function over latches.
 --
@@ -197,7 +197,7 @@ test = do
     let l2 =  mapL const l1
     p3     <- applyP l2 p1
     void $ addHandler p3 print
-    return fire
+    pure fire
 
 test_recursion1 :: IO (IO ())
 test_recursion1 = do
@@ -209,4 +209,4 @@ test_recursion1 = do
         l2      <- pure (mapL const l1);
     }
     void $ addHandler p2 print
-    return $ fire ()
+    pure $ fire ()


### PR DESCRIPTION
This pull request performs some large-scale tidying of the source code for `threepenny-gui`. In particular, we use `pure` instead of `return`.