### PR TITLE
Split off module `Graphics.UI.Threepenny.Server`

### DIFF
--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/Functions.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/Functions.hs
@@ -10,7 +10,7 @@ module Foreign.JavaScript.Functions
     , JavaScriptException
 #endif
     -- * Calling JavaScript from Haskell
-    , FFI, ffi, runFunction, callFunction
+    , FFI, ffi, runFunction, callFunction, root
     , NewJSObject, unsafeCreateJSObject
     , CallBufferMode(..), setCallBufferMode, getCallBufferMode, flushCallBuffer
     -- * Calling Haskell from JavaScript

--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/Server.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/Server.hs
@@ -10,7 +10,7 @@ module Foreign.JavaScript.Server
         , jsUseSSL)
     , ConfigSSL (..)
     , Server, MimeType, URI, loadFile, loadDirectory
-    , getServer, getCookies, root
+    , getServer, getCookies
     ) where
 
 import Foreign.JavaScript.CallHaskell

--- a/lib/threepenny-gui/samples/BarTab.hs
+++ b/lib/threepenny-gui/samples/BarTab.hs
@@ -11,7 +11,7 @@ import Graphics.UI.Threepenny.Core
 
 -- | Main entry point.
 main :: IO ()
-main = startGUI defaultConfig setup
+main = startBrowserGUI setup
 
 setup :: Window -> UI ()
 setup w = do

--- a/lib/threepenny-gui/samples/Buttons.hs
+++ b/lib/threepenny-gui/samples/Buttons.hs
@@ -5,6 +5,7 @@ import Paths
 
 import qualified Graphics.UI.Threepenny as UI
 import Graphics.UI.Threepenny.Core
+import Graphics.UI.Threepenny.Server
 
 {-----------------------------------------------------------------------------
     Buttons

--- a/lib/threepenny-gui/samples/CRUD.hs
+++ b/lib/threepenny-gui/samples/CRUD.hs
@@ -21,7 +21,7 @@ import Graphics.UI.Threepenny.Core hiding (delete)
     Main
 ------------------------------------------------------------------------------}
 main :: IO ()
-main = startGUI defaultConfig setup
+main = startBrowserGUI setup
 
 setup :: Window -> UI ()
 setup window = void $ mdo

--- a/lib/threepenny-gui/samples/Canvas.hs
+++ b/lib/threepenny-gui/samples/Canvas.hs
@@ -4,7 +4,7 @@ import Paths
 
 import qualified Graphics.UI.Threepenny as UI
 import Graphics.UI.Threepenny.Core
-
+import Graphics.UI.Threepenny.Server
 
 {-----------------------------------------------------------------------------
     Main
@@ -100,7 +100,7 @@ setup window = do
         canvas # UI.fillText   "is awesome" (140,60)
 
     -- draw the haskell logo
-    url <- UI.loadFile "image/png" "static/haskell-logo.png"
+    url <- loadFile "image/png" "static/haskell-logo.png"
     img <- UI.img # set UI.src url
 
     on UI.click drawImage $ const $ do

--- a/lib/threepenny-gui/samples/Chat.hs
+++ b/lib/threepenny-gui/samples/Chat.hs
@@ -10,6 +10,7 @@ import Paths
 
 import qualified Graphics.UI.Threepenny as UI
 import Graphics.UI.Threepenny.Core hiding (text)
+import Graphics.UI.Threepenny.Server
 
 {-----------------------------------------------------------------------------
     Chat

--- a/lib/threepenny-gui/samples/CurrencyConverter.hs
+++ b/lib/threepenny-gui/samples/CurrencyConverter.hs
@@ -9,7 +9,7 @@ import Graphics.UI.Threepenny.Core
     Main
 ------------------------------------------------------------------------------}
 main :: IO ()
-main = startGUI defaultConfig setup
+main = startBrowserGUI setup
 
 setup :: Window -> UI ()
 setup window = void $ do

--- a/lib/threepenny-gui/samples/DragNDropExample.hs
+++ b/lib/threepenny-gui/samples/DragNDropExample.hs
@@ -5,6 +5,7 @@ import Paths
 
 import qualified Graphics.UI.Threepenny as UI
 import Graphics.UI.Threepenny.Core
+import Graphics.UI.Threepenny.Server
 
 {-----------------------------------------------------------------------------
     Drag'N'Drop example

--- a/lib/threepenny-gui/samples/DrumMachine.hs
+++ b/lib/threepenny-gui/samples/DrumMachine.hs
@@ -4,6 +4,7 @@ import Paths
 
 import qualified Graphics.UI.Threepenny as UI
 import Graphics.UI.Threepenny.Core
+import Graphics.UI.Threepenny.Server
 
 {-----------------------------------------------------------------------------
     Configuration

--- a/lib/threepenny-gui/samples/FadeInFadeOut.hs
+++ b/lib/threepenny-gui/samples/FadeInFadeOut.hs
@@ -7,7 +7,7 @@ import Graphics.UI.Threepenny.JQuery
     Main
 ------------------------------------------------------------------------------}
 main :: IO ()
-main = startGUI defaultConfig setup
+main = startBrowserGUI setup
 
 setup :: Window -> UI ()
 setup w = do

--- a/lib/threepenny-gui/samples/Svg.hs
+++ b/lib/threepenny-gui/samples/Svg.hs
@@ -8,7 +8,7 @@ import qualified Graphics.UI.Threepenny.SVG  as SVG
     SVG
 ------------------------------------------------------------------------------}
 main :: IO ()
-main = startGUI defaultConfig setup
+main = startBrowserGUI setup
 
 setup :: Window -> UI ()
 setup w = void $ do

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Core.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Core.hs
@@ -69,10 +69,8 @@ import qualified Graphics.UI.Threepenny.Internal as Core
 import qualified Reactive.Threepenny             as Reactive
 
 -- exports
-import Foreign.JavaScript                   (Config(..), ConfigSSL (..), defaultConfig)
 import Graphics.UI.Threepenny.Internal
 import Reactive.Threepenny                  hiding (onChange)
-
 
 {-----------------------------------------------------------------------------
     Server

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Core.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Core.hs
@@ -5,8 +5,7 @@ module Graphics.UI.Threepenny.Core (
 
     -- * Server
     -- $server
-    Config(..), ConfigSSL (..), defaultConfig, startGUI,
-    loadFile, loadDirectory,
+    startBrowserGUI,
 
     -- * UI monad
     -- $ui

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Internal.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Internal.hs
@@ -7,7 +7,7 @@ module Graphics.UI.Threepenny.Internal (
 
     -- * Documentation
     Window, disconnect,
-    startGUI, loadFile, loadDirectory,
+    startBrowserGUI, startGUI, loadFile, loadDirectory,
 
     UI, runUI, MonadUI(..), throwUI, catchUI, handleUI,
     liftIOLater, askWindow, liftJSWindow,
@@ -52,6 +52,12 @@ data Window = Window
     , wChildren   :: Foreign.Vendor ()
                      -- children reachable from 'Element's
     }
+
+-- | Start a GUI session in a browser window.
+startBrowserGUI
+    :: (Window -> UI ()) -- ^ Run when the browser window is initialized.
+    -> IO ()
+startBrowserGUI = startGUI defaultConfig
 
 -- | Start server for GUI sessions.
 startGUI

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Server.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Server.hs
@@ -8,10 +8,12 @@ module Graphics.UI.Threepenny.Server (
     loadFile, loadDirectory,
     ) where
 
-import Foreign.JavaScript
+import qualified Foreign.JavaScript.Server as JS
+
+import Foreign.JavaScript.Server
     ( Config(..), ConfigSSL (..), defaultConfig )
 import Graphics.UI.Threepenny.Internal
-    ( loadDirectory, loadFile, startGUI )
+    ( Window, UI, liftJSWindow, setupWindow )
 
 {-----------------------------------------------------------------------------
     Server
@@ -33,3 +35,20 @@ See 'CallBufferMode' for more information.
 
 -}
 
+-- | Start server for GUI sessions.
+startGUI
+    :: Config               -- ^ Server configuration.
+    -> (Window -> UI ())    -- ^ Action to run whenever a client browser connects.
+    -> IO ()
+startGUI config = JS.serve config . setupWindow
+
+-- | Begin to serve a local file with a given 'MimeType' under a relative URI.
+loadFile
+    :: String    -- ^ MIME type
+    -> FilePath  -- ^ Local path to the file
+    -> UI String -- ^ Relative URI under which this file is now accessible
+loadFile x y = liftJSWindow $ \w -> JS.loadFile (JS.getServer w) x y
+
+-- | Make a local directory available under a relative URI.
+loadDirectory :: FilePath -> UI String
+loadDirectory x = liftJSWindow $ \w -> JS.loadDirectory (JS.getServer w) x

--- a/lib/threepenny-gui/src/Graphics/UI/Threepenny/Server.hs
+++ b/lib/threepenny-gui/src/Graphics/UI/Threepenny/Server.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Server-related functionality.
+module Graphics.UI.Threepenny.Server (
+    -- $server
+    Config(..), ConfigSSL (..), defaultConfig, startGUI,
+    loadFile, loadDirectory,
+    ) where
+
+import Foreign.JavaScript
+    ( Config(..), ConfigSSL (..), defaultConfig )
+import Graphics.UI.Threepenny.Internal
+    ( loadDirectory, loadFile, startGUI )
+
+{-----------------------------------------------------------------------------
+    Server
+------------------------------------------------------------------------------}
+{- $server
+
+To display the user interface, you have to start a server using 'startGUI'.
+Then, visit the URL <http://localhost:8023/> in your browser
+(assuming that you use the default server configuration 'defaultConfig',
+or have set the port number to @jsPort=Just 8023@.)
+
+The server is multithreaded.
+FFI calls can be made concurrently, but events are handled sequentially.
+
+FFI calls can be __buffered__,
+so in some circumstances, it may happen that you manipulate the browser window,
+but the effect is not immediately visible.
+See 'CallBufferMode' for more information.
+
+-}
+

--- a/lib/threepenny-gui/threepenny-gui.cabal
+++ b/lib/threepenny-gui/threepenny-gui.cabal
@@ -75,7 +75,6 @@ library
     Graphics.UI.Threepenny.Elements
     Graphics.UI.Threepenny.Events
     Graphics.UI.Threepenny.JQuery
-    Graphics.UI.Threepenny.Server
     Graphics.UI.Threepenny.SVG
     Graphics.UI.Threepenny.SVG.Attributes
     Graphics.UI.Threepenny.SVG.Elements
@@ -99,6 +98,7 @@ library
 
   if impl(ghc)
     exposed-modules:
+      Graphics.UI.Threepenny.Server
       Graphics.UI.Threepenny.Timer
     build-depends:
         stm                        >=2.2   && <2.6

--- a/lib/threepenny-gui/threepenny-gui.cabal
+++ b/lib/threepenny-gui/threepenny-gui.cabal
@@ -75,6 +75,7 @@ library
     Graphics.UI.Threepenny.Elements
     Graphics.UI.Threepenny.Events
     Graphics.UI.Threepenny.JQuery
+    Graphics.UI.Threepenny.Server
     Graphics.UI.Threepenny.SVG
     Graphics.UI.Threepenny.SVG.Attributes
     Graphics.UI.Threepenny.SVG.Elements


### PR DESCRIPTION
This pull request splits off a module `Graphics.UI.Threepenny.Server`.

The goal is that the rest of the library without this module can be compiled with MicroHs.