### PR TITLE
Update to latest MicroHs

### DIFF
--- a/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallBuffer.hs
+++ b/lib/javascript-ffi-threepenny/src/Foreign/JavaScript/CallBuffer.hs
@@ -10,23 +10,6 @@ module Foreign.JavaScript.CallBuffer
 
 import Foreign.JavaScript.Types
 
-#if defined(__MHS__)
-{-----------------------------------------------------------------------------
-    MicroHs
-------------------------------------------------------------------------------}
-setCallBufferMode :: Window -> CallBufferMode -> IO ()
-setCallBufferMode _ _ = pure ()
-
-getCallBufferMode :: Window -> IO CallBufferMode
-getCallBufferMode _ = pure NoBuffering
-
-flushCallBuffer :: Window -> IO ()
-flushCallBuffer _ = pure ()
-
-bufferRunEval :: Window -> String -> IO ()
-bufferRunEval Window{runEval} code = runEval code
-
-#else
 {-----------------------------------------------------------------------------
    GHC
 ------------------------------------------------------------------------------}
@@ -77,4 +60,3 @@ bufferRunEval Window{wCallBufferMode,wCallBuffer,runEval} code = do
         Nothing    -> pure ()
         Just code1 -> runEval code1
 
-#endif

--- a/lib/threepenny-gui/src/Reactive/Threepenny/PulseLatch.hs
+++ b/lib/threepenny-gui/src/Reactive/Threepenny/PulseLatch.hs
@@ -27,11 +27,6 @@ import qualified Data.Unique.Really.Map as Map
 import Reactive.Threepenny.Monads
 import Reactive.Threepenny.Types
 
-#if defined(__MHS__)
-modifyIORef' :: IORef a -> (a -> a) -> IO ()
-modifyIORef' ref f = atomicModifyIORef ref (\a -> (f a, ()))
-#endif
-
 {-----------------------------------------------------------------------------
     Pulse
 ------------------------------------------------------------------------------}


### PR DESCRIPTION
This pull request updates to the latest MicroHs. In particular,

* We use the existing implementation of `wCallBuffer` as MicroHs now supports `TVar`.
* We use `modifyIORef'` that has been added to MicroHs